### PR TITLE
Report unreadable Actions settings as undetermined instead of nothing

### DIFF
--- a/docs/rules/actions-can-approve-prs.md
+++ b/docs/rules/actions-can-approve-prs.md
@@ -56,7 +56,9 @@ Behavior:
 
 - if `can_approve_pull_request_reviews == true`, it creates a medium finding
 - if the value is `false`, it treats that as the desired setting
-- if GitHub returns `403` or `404`, the scanner silently skips this sub-check
+- if GitHub returns `403` or `404`, the value cannot be read and the rule reports an
+  informational `undetermined-*` finding rather than staying silent — an unreadable
+  setting is unknown, not clean
 - if the repository Actions settings endpoint itself cannot be read, the CLI can return an informational `settings-check-unavailable` or `settings-check-failed` finding for this rule
 
 This rule uses the repository Actions settings API, so full scans need fine-grained `Administration: Read` repository permission, or classic PAT `repo`.

--- a/docs/rules/allowed-actions-policy.md
+++ b/docs/rules/allowed-actions-policy.md
@@ -63,6 +63,10 @@ Behavior:
 - if `allowed_actions == all`, it creates a medium finding
 - if `allowed_actions == local_only`, it creates an informational "good" finding
 - if `allowed_actions == selected`, it treats that as the desired setting
+- if Actions is enabled but GitHub reports no `allowed_actions` value at all (observed when
+  an org or enterprise policy governs the repository), the rule reports an informational
+  `undetermined-*` finding rather than staying silent — an unreadable setting is unknown,
+  not clean
 - if the repository settings endpoint is unavailable without auth, the CLI can return an informational `settings-check-unavailable` finding for this rule
 - if the CLI is authenticated but still cannot read the setting, it can return an informational `settings-check-failed` finding for this rule
 

--- a/docs/rules/default-workflow-permissions.md
+++ b/docs/rules/default-workflow-permissions.md
@@ -60,7 +60,9 @@ Behavior:
 
 - if `default_workflow_permissions == write`, it creates a high finding
 - if `default_workflow_permissions == read`, it treats that as the desired setting
-- if GitHub returns `403` or `404`, the scanner silently skips this sub-check
+- if GitHub returns `403` or `404`, the value cannot be read and the rule reports an
+  informational `undetermined-*` finding rather than staying silent — an unreadable
+  setting is unknown, not clean
 - if the repository Actions settings endpoint itself cannot be read, the CLI can return an informational `settings-check-unavailable` or `settings-check-failed` finding for this rule
 
 This rule uses the repository Actions settings API, so full scans need fine-grained `Administration: Read` repository permission, or classic PAT `repo`.

--- a/docs/rules/fork-pr-workflow-approval.md
+++ b/docs/rules/fork-pr-workflow-approval.md
@@ -64,7 +64,9 @@ Behavior:
 
 - if the value is anything other than `all_external_contributors`, it creates a high finding
 - if the value is `all_external_contributors`, it treats that as the desired setting
-- if GitHub returns `403` or `404`, the scanner silently skips this sub-check
+- if GitHub returns `403` or `404`, the value cannot be read and the rule reports an
+  informational `undetermined-*` finding rather than staying silent — an unreadable
+  setting is unknown, not clean
 - if the repository Actions settings endpoint itself cannot be read, the CLI can return an informational `settings-check-unavailable` or `settings-check-failed` finding for this rule
 
 This rule uses the repository Actions settings API, so full scans need fine-grained `Administration: Read` repository permission, or classic PAT `repo`.

--- a/internal/scanner/facts.go
+++ b/internal/scanner/facts.go
@@ -45,6 +45,41 @@ type ActionsSettingsFacts struct {
 	AccessFinding              *Finding
 	DefaultWorkflowPermissions *github.DefaultWorkflowPermissionRepository
 	ForkPRContributorApproval  *github.ContributorApprovalPermissions
+
+	// Undetermined records settings the scanner tried to read but could not,
+	// keyed by the constants below and holding a human-readable cause.
+	//
+	// A nil settings pointer is ambiguous on its own: it means either "GitHub
+	// told us nothing because the sub-call was refused" or "the field was
+	// genuinely absent". Rules previously could not tell those apart from
+	// "everything is fine", so a refused sub-call made a rule emit no finding,
+	// no success, and no warning — the check silently vanished from the report
+	// while the scan still looked clean. This map is what lets a rule say "could
+	// not determine" out loud instead.
+	Undetermined map[string]string
+}
+
+// Keys for ActionsSettingsFacts.Undetermined. One key per API sub-call, since
+// that is the granularity at which a read succeeds or fails.
+const (
+	settingAllowedActions      = "allowed-actions policy"
+	settingWorkflowPermissions = "workflow permissions"
+	settingForkPRApproval      = "fork-PR contributor approval"
+)
+
+// markUndetermined records that a setting could not be read, and why.
+func (f *ActionsSettingsFacts) markUndetermined(setting, cause string) {
+	if f.Undetermined == nil {
+		f.Undetermined = make(map[string]string)
+	}
+	f.Undetermined[setting] = cause
+}
+
+// undeterminedCause returns the recorded cause and whether the setting was
+// marked undetermined.
+func (f *ActionsSettingsFacts) undeterminedCause(setting string) (string, bool) {
+	cause, ok := f.Undetermined[setting]
+	return cause, ok
 }
 
 type DependabotFacts struct {

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -480,6 +480,44 @@ func appendSettingsAccessFinding(findings []Finding, facts *ScanFacts) []Finding
 	return append(findings, *facts.ActionsSettings.AccessFinding)
 }
 
+// undeterminedSettingFinding reports that a rule could not be evaluated because
+// its input could not be read.
+//
+// This exists so a rule never silently produces nothing. "No finding" is
+// indistinguishable from "clean" in every report format, so a check that
+// quietly disappears reads as a pass — the most dangerous possible failure for a
+// security scanner. Severity is info: it is not a vulnerability, it is a hole in
+// the scan's coverage, and it should not inflate the finding counts operators
+// triage on.
+//
+// The ID mirrors the success-finding scheme (one per rule) so two rules reading
+// the same refused endpoint do not collide and get deduplicated away.
+func undeterminedSettingFinding(ruleName, setting, cause string) Finding {
+	return Finding{
+		ID:       "undetermined-" + sanitizeID(ruleName),
+		Rule:     ruleName,
+		Category: ruleCategory(ruleName),
+		Severity: SeverityInfo,
+		Title:    "Could not determine " + setting,
+		Description: "This check did not run because the " + setting + " could not be read: " + cause +
+			". The result is unknown — treat it as unchecked, not as passing.",
+		Location:    "Repository Actions settings",
+		Remediation: "Re-run with a token that has repository admin access (fine-grained `Administration: Read`, or classic PAT `repo`), or review the setting manually under Settings → Actions → General.",
+	}
+}
+
+// undeterminedFindingFor returns a "could not determine" finding when the given
+// setting was not readable, or nil when it was. A non-nil result means the rule
+// must stop rather than evaluate a nil value it cannot interpret.
+func undeterminedFindingFor(facts *ScanFacts, ruleName, setting string) *Finding {
+	cause, ok := facts.ActionsSettings.undeterminedCause(setting)
+	if !ok {
+		return nil
+	}
+	f := undeterminedSettingFinding(ruleName, setting, cause)
+	return &f
+}
+
 func actionsSettingsEnabled(facts *ScanFacts) bool {
 	permissions := facts.ActionsSettings.Permissions
 	if permissions == nil {
@@ -593,6 +631,10 @@ func evaluateAllowedActionsPolicyRule(facts *ScanFacts) []Finding {
 	findings := make([]Finding, 0)
 	findings = appendSettingsAccessFinding(findings, facts)
 
+	if undetermined := undeterminedFindingFor(facts, ruleNameAllowedActionsPolicy, settingAllowedActions); undetermined != nil {
+		return append(findings, *undetermined)
+	}
+
 	permissions := facts.ActionsSettings.Permissions
 	if !actionsSettingsEnabled(facts) || permissions.AllowedActions == nil {
 		return findings
@@ -615,6 +657,10 @@ func evaluateAllowedActionsPolicyRule(facts *ScanFacts) []Finding {
 func evaluateDefaultWorkflowPermissionsRule(facts *ScanFacts) []Finding {
 	findings := make([]Finding, 0)
 	findings = appendSettingsAccessFinding(findings, facts)
+
+	if undetermined := undeterminedFindingFor(facts, ruleNameDefaultWorkflowPermissions, settingWorkflowPermissions); undetermined != nil {
+		return append(findings, *undetermined)
+	}
 
 	perms := facts.ActionsSettings.DefaultWorkflowPermissions
 	if !actionsSettingsEnabled(facts) || perms == nil {
@@ -639,6 +685,10 @@ func evaluateActionsCanApprovePRsRule(facts *ScanFacts) []Finding {
 	findings := make([]Finding, 0)
 	findings = appendSettingsAccessFinding(findings, facts)
 
+	if undetermined := undeterminedFindingFor(facts, ruleNameActionsCanApprovePRs, settingWorkflowPermissions); undetermined != nil {
+		return append(findings, *undetermined)
+	}
+
 	perms := facts.ActionsSettings.DefaultWorkflowPermissions
 	if !actionsSettingsEnabled(facts) || perms == nil || perms.CanApprovePullRequestReviews == nil || !*perms.CanApprovePullRequestReviews {
 		return findings
@@ -659,6 +709,10 @@ func evaluateActionsCanApprovePRsRule(facts *ScanFacts) []Finding {
 func evaluateForkPRContributorApprovalRule(facts *ScanFacts) []Finding {
 	findings := make([]Finding, 0)
 	findings = appendSettingsAccessFinding(findings, facts)
+
+	if undetermined := undeterminedFindingFor(facts, ruleNameForkPRContributorApproval, settingForkPRApproval); undetermined != nil {
+		return append(findings, *undetermined)
+	}
 
 	policy := facts.ActionsSettings.ForkPRContributorApproval
 	if !actionsSettingsEnabled(facts) || policy == nil || policy.ApprovalPolicy == forkPRApprovalAllExternal {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -164,30 +164,7 @@ func (s *Scanner) ScanRepoWithOptions(ctx context.Context, owner, repo string, o
 	}
 
 	for _, r := range rules {
-		if dbg != nil {
-			dbg(repoFull, "rule:start "+r.Name)
-		}
-		findings := r.run(facts)
-		findings = applyRuleConfig(findings, r, opts.Config)
-		if len(findings) == 0 && opts.IncludeSuccess {
-			if success := buildRuleSuccessFinding(r, facts, opts.Config); success != nil {
-				if dbg != nil {
-					dbg(repoFull, "rule:pass "+r.Name)
-				}
-				result.Findings = append(result.Findings, *success)
-				continue
-			}
-		}
-		if dbg != nil {
-			if len(findings) == 0 {
-				dbg(repoFull, "rule:pass "+r.Name+" (no findings)")
-			} else {
-				for _, f := range findings {
-					dbg(repoFull, "rule:finding "+r.Name+" id="+f.ID+" severity="+f.Severity)
-				}
-			}
-		}
-		result.Findings = append(result.Findings, findings...)
+		result.Findings = append(result.Findings, evaluateRule(r, facts, opts, repoFull, dbg)...)
 	}
 	result.Findings = applySuppressions(result.Findings, opts.Config)
 	result.Findings = addFixURLs(result.Findings, owner, repo, facts.DefaultBranch)
@@ -196,6 +173,46 @@ func (s *Scanner) ScanRepoWithOptions(ctx context.Context, owner, repo string, o
 	sortFindings(result.Findings)
 
 	return result, nil
+}
+
+// evaluateRule runs one rule and returns what it contributes to the report:
+// its findings, or a success finding when it produced none and successes were
+// requested.
+func evaluateRule(r rule, facts *ScanFacts, opts ScanOptions, repoFull string, dbg DebugLogger) []Finding {
+	if dbg != nil {
+		dbg(repoFull, "rule:start "+r.Name)
+	}
+
+	findings := applyRuleConfig(r.run(facts), r, opts.Config)
+	if len(findings) > 0 {
+		if dbg != nil {
+			for _, f := range findings {
+				dbg(repoFull, "rule:finding "+r.Name+" id="+f.ID+" severity="+f.Severity)
+			}
+		}
+		return findings
+	}
+
+	if opts.IncludeSuccess {
+		if success := buildRuleSuccessFinding(r, facts, opts.Config); success != nil {
+			if dbg != nil {
+				dbg(repoFull, "rule:pass "+r.Name)
+			}
+			return []Finding{*success}
+		}
+		// Neither a finding nor a success: the rule contributed nothing to the
+		// report at all. This used to log rule:pass, which read as "evaluated
+		// and clean" while the rule was in fact absent from the output.
+		if dbg != nil {
+			dbg(repoFull, "rule:silent "+r.Name+" (no finding and no success — rule did not report)")
+		}
+		return nil
+	}
+
+	if dbg != nil {
+		dbg(repoFull, "rule:pass "+r.Name+" (no findings)")
+	}
+	return nil
 }
 
 func classifyGitHubRepoAccessError(err error) string {

--- a/internal/scanner/settings.go
+++ b/internal/scanner/settings.go
@@ -37,24 +37,7 @@ func (c *factCollector) collectActionsSettingsFacts(ctx context.Context, owner, 
 	}
 	permissions, resp, err := c.client.Repositories.GetActionsPermissions(ctx, owner, repo)
 	if err != nil {
-		// Three distinct causes, three distinct messages:
-		//   - unauthenticated      → tell them to supply a token
-		//   - authenticated denial → tell them exactly which permission to add
-		//   - transient (5xx, …)   → an incomplete-scan warning with the real cause
-		// A denial is determinate and fully explained by its finding, so it is
-		// NOT also counted as incomplete (that would double-report and erode
-		// trust in the incomplete warning).
-		switch {
-		case !c.authenticated:
-			setUnauthenticatedAccessFinding(&facts)
-		case isAccessDenied(resp):
-			setAccessDeniedFinding(&facts)
-		default:
-			c.addWarning("actions settings", describeFetchError(err))
-		}
-		if dbg != nil {
-			dbg(repoFull, "actions/permissions fetch error: "+err.Error())
-		}
+		c.recordSettingsFetchFailure(&facts, resp, err, repoFull, dbg)
 		return facts
 	}
 	if dbg != nil {
@@ -64,6 +47,15 @@ func (c *factCollector) collectActionsSettingsFacts(ctx context.Context, owner, 
 	}
 
 	facts.Permissions = permissions
+	// Actions is enabled but GitHub did not report a policy value. Observed when
+	// an org or enterprise policy governs the repository. Without this the rule
+	// would emit neither a finding nor a success and vanish from the report.
+	if permissions.AllowedActions == nil && (permissions.Enabled == nil || *permissions.Enabled) {
+		facts.markUndetermined(settingAllowedActions, "GitHub did not report an allowed-actions value for this repository")
+		if dbg != nil {
+			dbg(repoFull, "actions/permissions: allowed_actions absent — undetermined")
+		}
+	}
 	if permissions.Enabled != nil && !*permissions.Enabled {
 		if dbg != nil {
 			dbg(repoFull, "actions disabled for this repo — skipping workflow/fork-pr settings")
@@ -78,6 +70,30 @@ func (c *factCollector) collectActionsSettingsFacts(ctx context.Context, owner, 
 	}
 
 	return facts
+}
+
+// recordSettingsFetchFailure classifies a failed top-level Actions settings
+// read. Three distinct causes get three distinct messages:
+//
+//   - unauthenticated      → tell them to supply a token
+//   - authenticated denial → tell them exactly which permission to add
+//   - transient (5xx, …)   → an incomplete-scan warning with the real cause
+//
+// A denial is determinate and fully explained by its finding, so it is NOT also
+// counted as incomplete — that would double-report and erode trust in the
+// incomplete warning.
+func (c *factCollector) recordSettingsFetchFailure(facts *ActionsSettingsFacts, resp *github.Response, err error, repoFull string, dbg DebugLogger) {
+	switch {
+	case !c.authenticated:
+		setUnauthenticatedAccessFinding(facts)
+	case isAccessDenied(resp):
+		setAccessDeniedFinding(facts)
+	default:
+		c.addWarning("actions settings", describeFetchError(err))
+	}
+	if dbg != nil {
+		dbg(repoFull, "actions/permissions fetch error: "+err.Error())
+	}
 }
 
 // setAccessDeniedFinding records that an authenticated token was accepted but
@@ -130,11 +146,16 @@ func fetchAuthenticatedActionsSettings(ctx context.Context, c *factCollector, ow
 				perms.GetDefaultWorkflowPermissions(), perms.GetCanApprovePullRequestReviews()))
 		}
 	case isAccessDenied(resp):
-		// Determinate "not accessible / not available" — nothing to flag.
+		// Determinate as an HTTP outcome, but NOT determinate as a security
+		// answer: the settings are whatever they are, we simply could not read
+		// them. Recording it lets the rules report "could not determine" rather
+		// than disappearing from the report entirely.
+		facts.markUndetermined(settingWorkflowPermissions, fmt.Sprintf("GitHub returned %d — the token cannot read this setting", resp.StatusCode))
 		if dbg != nil {
-			dbg(repoFull, fmt.Sprintf("workflow permissions fetch: status %d — skipped", resp.StatusCode))
+			dbg(repoFull, fmt.Sprintf("workflow permissions fetch: status %d — undetermined", resp.StatusCode))
 		}
 	default:
+		facts.markUndetermined(settingWorkflowPermissions, describeFetchError(err))
 		c.addWarning("workflow default permissions", describeFetchError(err))
 		if dbg != nil {
 			dbg(repoFull, "workflow permissions fetch could not be determined: "+describeFetchError(err))
@@ -152,10 +173,12 @@ func fetchAuthenticatedActionsSettings(ctx context.Context, c *factCollector, ow
 			dbg(repoFull, "fork-pr-approval: policy="+policy.ApprovalPolicy)
 		}
 	case isAccessDenied(resp):
+		facts.markUndetermined(settingForkPRApproval, fmt.Sprintf("GitHub returned %d — the token cannot read this setting", resp.StatusCode))
 		if dbg != nil {
-			dbg(repoFull, fmt.Sprintf("fork-pr-approval fetch: status %d — skipped", resp.StatusCode))
+			dbg(repoFull, fmt.Sprintf("fork-pr-approval fetch: status %d — undetermined", resp.StatusCode))
 		}
 	default:
+		facts.markUndetermined(settingForkPRApproval, describeFetchError(err))
 		c.addWarning("fork-PR contributor approval", describeFetchError(err))
 		if dbg != nil {
 			dbg(repoFull, "fork-pr-approval fetch could not be determined: "+describeFetchError(err))

--- a/internal/scanner/settings_test.go
+++ b/internal/scanner/settings_test.go
@@ -248,7 +248,11 @@ func TestEvaluateForkPRApprovalPolicy_AllExternal(t *testing.T) {
 	}
 }
 
-func TestEvaluateForkPRApprovalPolicy_ForbiddenSkips(t *testing.T) {
+// A refused fork-PR sub-call must be reported as undetermined, not skipped. The
+// top-level settings call succeeded, so no access finding is recorded, and the
+// rule used to emit nothing at all — leaving a high-severity check silently
+// absent from a report that still looked clean.
+func TestEvaluateForkPRApprovalPolicy_ForbiddenReportsUndetermined(t *testing.T) {
 	s, mux := newTestScanner(t, true)
 	handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "selected"})
 	handleJSON(mux, "/repos/owner/repo/actions/permissions/workflow", map[string]any{"default_workflow_permissions": "read", "can_approve_pull_request_reviews": false})
@@ -258,9 +262,63 @@ func TestEvaluateForkPRApprovalPolicy_ForbiddenSkips(t *testing.T) {
 			t.Errorf("failed to write response: %v", err)
 		}
 	})
+
 	findings := collectAndEvaluateActionsSettings(t, s)
-	if len(findings) != 0 {
-		t.Fatalf("findings = %+v", findings)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %+v, want exactly one undetermined finding", findings)
+	}
+	f := findings[0]
+	if f.Rule != ruleNameForkPRContributorApproval {
+		t.Fatalf("rule = %q, want %q", f.Rule, ruleNameForkPRContributorApproval)
+	}
+	if f.Severity != SeverityInfo {
+		t.Fatalf("severity = %q, want info — a coverage hole is not a vulnerability", f.Severity)
+	}
+	if f.Success {
+		t.Fatal("an undetermined check must never be recorded as a success")
+	}
+	if !strings.Contains(f.Description, "403") {
+		t.Fatalf("description should name the cause, got %q", f.Description)
+	}
+}
+
+// Both rules that read /actions/permissions/workflow must report undetermined
+// when it is refused, and their findings must not collide under dedupe.
+func TestEvaluateWorkflowSettings_ForbiddenReportsUndeterminedForBothRules(t *testing.T) {
+	s, mux := newTestScanner(t, true)
+	handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "selected"})
+	mux.HandleFunc("/repos/owner/repo/actions/permissions/workflow", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	handleJSON(mux, "/repos/owner/repo/actions/permissions/fork-pr-contributor-approval", map[string]any{"approval_policy": "all_external_contributors"})
+
+	findings := collectAndEvaluateActionsSettings(t, s)
+	got := make(map[string]bool)
+	for _, f := range findings {
+		got[f.Rule] = true
+	}
+	for _, want := range []string{ruleNameDefaultWorkflowPermissions, ruleNameActionsCanApprovePRs} {
+		if !got[want] {
+			t.Fatalf("rule %q did not report undetermined; findings = %+v", want, findings)
+		}
+	}
+}
+
+// An absent allowed_actions value on an enabled repository is undetermined, not
+// clean. GitHub omits it when an org or enterprise policy governs the repo.
+func TestEvaluateAllowedActions_AbsentValueReportsUndetermined(t *testing.T) {
+	s, mux := newTestScanner(t, true)
+	handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true})
+	handleJSON(mux, "/repos/owner/repo/actions/permissions/workflow", map[string]any{"default_workflow_permissions": "read", "can_approve_pull_request_reviews": false})
+	handleJSON(mux, "/repos/owner/repo/actions/permissions/fork-pr-contributor-approval", map[string]any{"approval_policy": "all_external_contributors"})
+
+	facts := &ScanFacts{ActionsSettings: newTestFactCollector(s).collectActionsSettingsFacts(context.Background(), "owner", "repo", nil)}
+	findings := evaluateAllowedActionsPolicyRule(facts)
+	if len(findings) != 1 || findings[0].Rule != ruleNameAllowedActionsPolicy {
+		t.Fatalf("findings = %+v, want one undetermined allowed-actions finding", findings)
+	}
+	if findings[0].Severity != SeverityInfo || findings[0].Success {
+		t.Fatalf("undetermined finding = %+v, want info severity and not a success", findings[0])
 	}
 }
 
@@ -329,11 +387,12 @@ func TestFetchAuthenticatedSettings_TransientErrorsWarn(t *testing.T) {
 	}
 }
 
-// A 403/404 on the sub-calls is a determinate denial: skipped, with neither a
-// finding nor an incomplete warning (the main settings finding already explains
-// the missing permission). This covers the default-workflow-permissions skip
-// branch that the fork-PR test does not.
-func TestFetchAuthenticatedSettings_DeniedSkipsQuietly(t *testing.T) {
+// A 403/404 on the sub-calls leaves the values unset and raises no incomplete
+// warning — the denial is determinate as an HTTP outcome, so it is not a
+// transient failure. The rules still surface it as an undetermined finding
+// (see the ForbiddenReportsUndetermined tests); this test covers only the
+// collection side.
+func TestFetchAuthenticatedSettings_DeniedLeavesValuesUnset(t *testing.T) {
 	s, mux := newTestScanner(t, true)
 	handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "selected"})
 	mux.HandleFunc("/repos/owner/repo/actions/permissions/workflow", func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
R10: when a settings sub-call was refused, the value stayed nil and the rules
reading it emitted no finding, no success, and no warning. The check simply
vanished from the report, which in every output format is indistinguishable
from a clean pass. A token that can read /actions/permissions but is refused on
/actions/permissions/workflow silently dropped a high and a medium rule from the
scan while the run still looked healthy.

A nil settings pointer is ambiguous on its own -- "refused" and "absent" and
"fine" all look the same -- so the fact model now records why a setting could
not be read, and the rules turn that into an explicit informational finding.
Info severity is deliberate: a coverage hole is not a vulnerability, and it
should not inflate the counts operators triage on.

Covers three cases: a refused or failed /actions/permissions/workflow call
(rules 5 and 6), a refused or failed fork-PR approval call (rule 7), and an
enabled repository where GitHub reports no allowed_actions value at all, which
happens when an org or enterprise policy governs the repo (rule 4).

Finding IDs follow the per-rule success-finding scheme so the two rules sharing
the workflow-permissions endpoint do not collide and get deduplicated away.

R19: a rule producing nothing logged "rule:pass", so debug output claimed the
rule evaluated and passed while it was absent from the report. Silent rules now
log rule:silent. The rule loop moved into evaluateRule to keep that branch
readable and to bring ScanRepoWithOptions back under the complexity limit.

The four settings rule docs claimed the scanner "silently skips" a denied
sub-check. That was accurate and is no longer true.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>