### PR TITLE
Stop reporting an unread settings API as "Actions is disabled"

### DIFF
--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -326,6 +326,11 @@ func successFinding(ruleName, severity, location, title, description string) *Fi
 func allowedActionsSuccessFinding(ruleName, severity string, facts *ScanFacts) *Finding {
 	permissions := facts.ActionsSettings.Permissions
 	if !actionsSettingsEnabled(facts) {
+		if !actionsObservedDisabled(facts) {
+			// The settings were never read. Claiming they are safely disabled
+			// would invent an observation.
+			return nil
+		}
 		return successMessage(ruleName, severity, "Repository Actions settings", "pass-disabled", nil)
 	}
 	if permissions == nil || permissions.AllowedActions == nil {
@@ -343,6 +348,11 @@ func allowedActionsSuccessFinding(ruleName, severity string, facts *ScanFacts) *
 
 func defaultWorkflowPermissionsSuccessFinding(ruleName, severity string, facts *ScanFacts) *Finding {
 	if !actionsSettingsEnabled(facts) {
+		if !actionsObservedDisabled(facts) {
+			// The settings were never read. Claiming they are safely disabled
+			// would invent an observation.
+			return nil
+		}
 		return successMessage(ruleName, severity, "Repository Actions settings", "pass-disabled", nil)
 	}
 	perms := facts.ActionsSettings.DefaultWorkflowPermissions
@@ -354,6 +364,11 @@ func defaultWorkflowPermissionsSuccessFinding(ruleName, severity string, facts *
 
 func actionsApprovePRsSuccessFinding(ruleName, severity string, facts *ScanFacts) *Finding {
 	if !actionsSettingsEnabled(facts) {
+		if !actionsObservedDisabled(facts) {
+			// The settings were never read. Claiming they are safely disabled
+			// would invent an observation.
+			return nil
+		}
 		return successMessage(ruleName, severity, "Repository Actions settings", "pass-disabled", nil)
 	}
 	perms := facts.ActionsSettings.DefaultWorkflowPermissions
@@ -365,6 +380,11 @@ func actionsApprovePRsSuccessFinding(ruleName, severity string, facts *ScanFacts
 
 func forkPRApprovalSuccessFinding(ruleName, severity string, facts *ScanFacts) *Finding {
 	if !actionsSettingsEnabled(facts) {
+		if !actionsObservedDisabled(facts) {
+			// The settings were never read. Claiming they are safely disabled
+			// would invent an observation.
+			return nil
+		}
 		return successMessage(ruleName, severity, "Repository Actions settings", "pass-disabled", nil)
 	}
 	policy := facts.ActionsSettings.ForkPRContributorApproval
@@ -524,6 +544,19 @@ func actionsSettingsEnabled(facts *ScanFacts) bool {
 		return false
 	}
 	return permissions.Enabled == nil || *permissions.Enabled
+}
+
+// actionsObservedDisabled reports that GitHub actually told us Actions is
+// switched off for this repository.
+//
+// This is deliberately narrower than !actionsSettingsEnabled(), which is also
+// true when Permissions is nil — that is, when the settings read failed and the
+// scanner knows nothing. Conflating the two let a failed read be reported as
+// the success "GitHub Actions are disabled for this repository", asserting a
+// fact never observed. Absence of evidence is not evidence of absence.
+func actionsObservedDisabled(facts *ScanFacts) bool {
+	permissions := facts.ActionsSettings.Permissions
+	return permissions != nil && permissions.Enabled != nil && !*permissions.Enabled
 }
 
 func evaluateDangerousWorkflowRule(facts *ScanFacts) []Finding {

--- a/internal/scanner/settings.go
+++ b/internal/scanner/settings.go
@@ -89,7 +89,16 @@ func (c *factCollector) recordSettingsFetchFailure(facts *ActionsSettingsFacts, 
 	case isAccessDenied(resp):
 		setAccessDeniedFinding(facts)
 	default:
-		c.addWarning("actions settings", describeFetchError(err))
+		// Transient failure: unlike the two cases above it produces no access
+		// finding, so without marking every setting undetermined the rules would
+		// fall through to their success helpers. Those read "Actions disabled"
+		// off a nil Permissions pointer and would report that as a pass — a
+		// claim about a setting the scanner never managed to read.
+		cause := describeFetchError(err)
+		c.addWarning("actions settings", cause)
+		for _, setting := range []string{settingAllowedActions, settingWorkflowPermissions, settingForkPRApproval} {
+			facts.markUndetermined(setting, cause)
+		}
 	}
 	if dbg != nil {
 		dbg(repoFull, "actions/permissions fetch error: "+err.Error())

--- a/internal/scanner/settings_test.go
+++ b/internal/scanner/settings_test.go
@@ -322,6 +322,69 @@ func TestEvaluateAllowedActions_AbsentValueReportsUndetermined(t *testing.T) {
 	}
 }
 
+// A transient failure on the top-level settings call produces no access
+// finding, so before this was fixed every settings rule fell through to its
+// success helper and reported "GitHub Actions are disabled for this repository"
+// — a claim about a setting the scanner never read. All four rules must instead
+// report undetermined, and the scan must be marked incomplete.
+func TestCollectActionsSettings_TransientErrorIsNotReportedAsDisabled(t *testing.T) {
+	s, mux := newTestScanner(t, true)
+	mux.HandleFunc("/repos/owner/repo/actions/permissions", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	collector := newTestFactCollector(s)
+	facts := &ScanFacts{ActionsSettings: collector.collectActionsSettingsFacts(context.Background(), "owner", "repo", nil)}
+
+	if len(collector.warnings) == 0 {
+		t.Fatal("a transient settings failure must mark the scan incomplete")
+	}
+
+	for _, tc := range []struct {
+		name string
+		run  func(*ScanFacts) []Finding
+		rule string
+	}{
+		{"allowed-actions", evaluateAllowedActionsPolicyRule, ruleNameAllowedActionsPolicy},
+		{"default-workflow-permissions", evaluateDefaultWorkflowPermissionsRule, ruleNameDefaultWorkflowPermissions},
+		{"actions-can-approve-prs", evaluateActionsCanApprovePRsRule, ruleNameActionsCanApprovePRs},
+		{"fork-pr-approval", evaluateForkPRContributorApprovalRule, ruleNameForkPRContributorApproval},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := tc.run(facts)
+			if len(findings) != 1 || findings[0].Rule != tc.rule {
+				t.Fatalf("findings = %+v, want one undetermined finding for %s", findings, tc.rule)
+			}
+			if findings[0].Success {
+				t.Fatal("an unread setting must never be reported as a success")
+			}
+		})
+	}
+}
+
+// actionsObservedDisabled must separate "GitHub said Actions is off" from "we
+// never managed to ask". Only the first may be reported as a pass.
+func TestActionsObservedDisabled_RequiresAnActualObservation(t *testing.T) {
+	unread := &ScanFacts{}
+	if actionsObservedDisabled(unread) {
+		t.Fatal("a nil Permissions pointer means unread, not disabled")
+	}
+
+	disabled := &ScanFacts{ActionsSettings: ActionsSettingsFacts{
+		Permissions: &github.ActionsPermissionsRepository{Enabled: github.Ptr(false)},
+	}}
+	if !actionsObservedDisabled(disabled) {
+		t.Fatal("enabled:false was observed and must count as disabled")
+	}
+
+	enabled := &ScanFacts{ActionsSettings: ActionsSettingsFacts{
+		Permissions: &github.ActionsPermissionsRepository{Enabled: github.Ptr(true)},
+	}}
+	if actionsObservedDisabled(enabled) {
+		t.Fatal("enabled:true is not disabled")
+	}
+}
+
 // A 404 on the main settings call (GitHub hides repos you can't admin behind a
 // 404, not just 403) must be treated identically to a 403 denial.
 func TestCollectActionsSettings_NotFoundTreatedAsDenial(t *testing.T) {


### PR DESCRIPTION
R9: when GET /actions/permissions failed transiently -- a 5xx or a timeout --
the collector recorded an incomplete-scan warning but no access finding, so
Permissions stayed nil. Every settings success helper opens with
!actionsSettingsEnabled(facts), which is true for a nil pointer, and all four
rules then reported the success "GitHub Actions are disabled for this
repository". That is a claim about a setting the scanner never managed to read,
and it may be flatly false.

Two changes, because either alone leaves a hole:

The transient branch now marks all three settings undetermined, so the rules
report explicitly rather than falling through to their success helpers. This
reuses the mechanism added for refused sub-calls.

actionsObservedDisabled separates "GitHub told us Actions is off" from "we never
managed to ask", and the success helpers now require the former before claiming
the disabled pass. actionsSettingsEnabled conflated the two; absence of evidence
was being treated as evidence of absence.

Denied and unauthenticated reads are unchanged: both already produce an access
finding that suppresses the success and explains the cause, and adding an
undetermined finding on top would double-report.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>