### PR TITLE
Mark scans incomplete when a workflow file cannot be parsed

### DIFF
--- a/internal/scanner/workflow.go
+++ b/internal/scanner/workflow.go
@@ -158,8 +158,19 @@ func parseAndAddWorkflowFile(ctx context.Context, file *github.RepositoryContent
 		if dbg != nil {
 			dbg(repoFull, "workflow parsed OK: "+*file.Path)
 		}
-	} else if dbg != nil {
-		dbg(repoFull, "workflow parse error "+*file.Path+": "+err.Error())
+	} else {
+		// Every workflow rule skips files it could not parse. Left unrecorded,
+		// a repository whose workflows all fail to parse produces zero findings
+		// and reads as a clean bill of health for files nobody actually checked.
+		// The parse error used to appear only under --debug.
+		//
+		// GitHub will not run a workflow it cannot parse either, so this is
+		// usually a broken file rather than a hidden risk — but "we could not
+		// look" must never render as "we looked and it was fine".
+		c.addWarning("workflow "+*file.Path, "could not be parsed as YAML: "+err.Error())
+		if dbg != nil {
+			dbg(repoFull, "workflow parse error "+*file.Path+": "+err.Error())
+		}
 	}
 
 	return fact, true

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -1,9 +1,11 @@
 package scanner
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/google/go-github/v84/github"
 	"gopkg.in/yaml.v3"
 )
 
@@ -180,6 +182,45 @@ func TestHasExplicitPermissions(t *testing.T) {
 	none := &WorkflowFile{}
 	if hasExplicitPermissions(none) {
 		t.Fatal("empty workflow should not be explicit")
+	}
+}
+
+// Every workflow rule skips files it could not parse, so a repository whose
+// only workflow is unparseable produces zero findings. Without an incomplete
+// marker that is indistinguishable from a clean scan — a pass for a file nobody
+// checked. The parse error used to surface only under --debug.
+func TestCollectWorkflowFacts_UnparseableWorkflowMarksScanIncomplete(t *testing.T) {
+	s, mux := newTestScanner(t, false)
+	handleJSON(mux, "/repos/owner/repo/contents/.github/workflows", []*github.RepositoryContent{{
+		Path: github.Ptr(".github/workflows/broken.yml"),
+		Name: github.Ptr("broken.yml"),
+	}})
+	handleJSON(mux, "/repos/owner/repo/contents/.github/workflows/broken.yml",
+		encodedContent(".github/workflows/broken.yml", "jobs:\n  build: [\n    steps:\n"))
+
+	collector := newTestFactCollector(s)
+	workflows := collector.collectWorkflowFacts(context.Background(), "owner", "repo", nil)
+
+	// The file is still collected — action-version-pinning falls back to its
+	// regex path for unparseable YAML — but it is not marked Valid.
+	if len(workflows) != 1 || workflows[0].Valid {
+		t.Fatalf("workflows = %+v, want one collected but invalid workflow", workflows)
+	}
+	if len(collector.warnings) != 1 {
+		t.Fatalf("warnings = %+v, want one parse warning", collector.warnings)
+	}
+	if !strings.Contains(collector.warnings[0].Area, "broken.yml") {
+		t.Fatalf("warning should name the file, got %+v", collector.warnings[0])
+	}
+
+	// The rules that require a parsed workflow stay quiet, which is exactly why
+	// the warning above has to exist.
+	facts := &ScanFacts{Workflows: workflows}
+	if findings := evaluateDangerousWorkflowRule(facts); len(findings) != 0 {
+		t.Fatalf("dangerous-trigger findings = %+v, want none for an unparsed file", findings)
+	}
+	if findings := evaluateWorkflowPermissionsRule(facts); len(findings) != 0 {
+		t.Fatalf("workflow-permissions findings = %+v, want none for an unparsed file", findings)
 	}
 }
 

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -186,7 +186,7 @@ func TestHasExplicitPermissions(t *testing.T) {
 }
 
 // Every workflow rule skips files it could not parse, so a repository whose
-// only workflow is unparseable produces zero findings. Without an incomplete
+// only workflow is unparsable produces zero findings. Without an incomplete
 // marker that is indistinguishable from a clean scan — a pass for a file nobody
 // checked. The parse error used to surface only under --debug.
 func TestCollectWorkflowFacts_UnparseableWorkflowMarksScanIncomplete(t *testing.T) {
@@ -202,7 +202,7 @@ func TestCollectWorkflowFacts_UnparseableWorkflowMarksScanIncomplete(t *testing.
 	workflows := collector.collectWorkflowFacts(context.Background(), "owner", "repo", nil)
 
 	// The file is still collected — action-version-pinning falls back to its
-	// regex path for unparseable YAML — but it is not marked Valid.
+	// regex path for unparsable YAML — but it is not marked Valid.
 	if len(workflows) != 1 || workflows[0].Valid {
 		t.Fatalf("workflows = %+v, want one collected but invalid workflow", workflows)
 	}


### PR DESCRIPTION
R1: every workflow rule skips files it could not parse, and the parse error was
only ever written to --debug output. A repository whose workflows all fail to
parse therefore produced zero findings and reported "pull_request_target event
is not used" and "workflow permissions are explicit" -- a clean bill of health
for files nobody actually checked.

Unparseable workflows now raise an incomplete-scan warning, which already exists
for exactly this purpose and which the output already surfaces as "the findings
are partial".

The practical risk is low, since GitHub will not run a workflow it cannot parse
either; the real hazard is a divergence between GitHub's parser and
gopkg.in/yaml.v3. Either way "we could not look" must never render as "we looked
and it was fine".

The file is still collected rather than dropped, because action-version-pinning
deliberately falls back to a regex scan for unparseable YAML and would otherwise
lose coverage. The new test pins both halves: the fallback still sees the file,
and the two rules that need a parsed workflow stay quiet -- which is precisely
why the warning has to exist.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>