### PR TITLE
Include the ref in unpinned-action finding IDs so siblings stop colliding

### DIFF
--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -603,7 +603,13 @@ func evaluateActionVersionPinningRule(facts *ScanFacts) []Finding {
 				"Ref":    action.version,
 			})
 			findings = append(findings, Finding{
-				ID:          fmt.Sprintf("unpinned-%s-%s", wf.Path, sanitizeID(action.name)),
+				// The ref is part of the ID because one file can reference the
+				// same action at two different mutable refs — actions/checkout@v4
+				// in one job and @v3 in another. Keying on path+name alone made
+				// those two findings share an ID, and dedupeFindings silently
+				// dropped the second: a real unpinned action disappearing from
+				// the report because a sibling finding got there first.
+				ID:          fmt.Sprintf("unpinned-%s-%s-%s", wf.Path, sanitizeID(action.name), sanitizeID(action.version)),
 				Severity:    SeverityHigh,
 				Title:       msg.Title,
 				Description: msg.Description,

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -479,14 +479,14 @@ func TestScanRepo_EndToEndMixedFindings(t *testing.T) {
 	}
 
 	wantIDs := map[string]bool{
-		"dangerous-trigger-.github/workflows/ci.yml":           false,
-		"unpinned-.github/workflows/ci.yml-actions-checkout":   false,
-		"no-permissions-.github/workflows/ci.yml":              false,
-		"settings-all-actions-allowed":                         false,
-		"settings-default-permissions-write":                   false,
-		"settings-actions-can-approve-prs":                     false,
-		"settings-fork-pr-contributor-approval-too-permissive": false,
-		"update-tool-missing-actions":                          false,
+		"dangerous-trigger-.github/workflows/ci.yml":            false,
+		"unpinned-.github/workflows/ci.yml-actions-checkout-v4": false,
+		"no-permissions-.github/workflows/ci.yml":               false,
+		"settings-all-actions-allowed":                          false,
+		"settings-default-permissions-write":                    false,
+		"settings-actions-can-approve-prs":                      false,
+		"settings-fork-pr-contributor-approval-too-permissive":  false,
+		"update-tool-missing-actions":                           false,
 	}
 	for _, finding := range result.Findings {
 		if _, ok := wantIDs[finding.ID]; ok {

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -224,6 +224,40 @@ func TestCollectWorkflowFacts_UnparseableWorkflowMarksScanIncomplete(t *testing.
 	}
 }
 
+// One file can reference the same action at two different mutable refs. The
+// finding ID keyed only on path+action name, so both findings collided and
+// dedupeFindings dropped the second — a real unpinned action vanishing from the
+// report because a sibling got there first.
+func TestEvaluateActionVersionPinningRule_SameActionTwoRefsBothReported(t *testing.T) {
+	content := `jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+  release:
+    steps:
+      - uses: actions/checkout@v3
+`
+	workflow := &WorkflowFile{}
+	if err := yaml.Unmarshal([]byte(content), workflow); err != nil {
+		t.Fatalf("yaml.Unmarshal() error: %v", err)
+	}
+
+	facts := &ScanFacts{Workflows: []WorkflowFact{{
+		Path:     ".github/workflows/ci.yml",
+		Content:  content,
+		Workflow: workflow,
+		Valid:    true,
+	}}}
+
+	findings := dedupeFindings(evaluateActionVersionPinningRule(facts))
+	if len(findings) != 2 {
+		t.Fatalf("findings = %+v, want both unpinned refs reported", findings)
+	}
+	if findings[0].ID == findings[1].ID {
+		t.Fatalf("finding IDs collide (%q); dedupe would drop one", findings[0].ID)
+	}
+}
+
 func TestEvaluateWorkflowRules_Integration(t *testing.T) {
 	content := "on: pull_request_target\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
 	workflow := &WorkflowFile{}


### PR DESCRIPTION
R3: the ID was unpinned-<path>-<action name>, carrying neither the ref nor the
line, while dedupeFindings keys purely on ID. A workflow referencing the same
action at two different mutable refs -- actions/checkout@v4 in one job and @v3
in another -- produced two findings with identical IDs, and the second was
silently dropped. A genuinely unpinned action disappeared from the report
because a sibling finding got there first.

The ref is now part of the ID. Cross-file duplicates were already distinct
because the path is in the ID, which is why gasa-fail never surfaced this: its
two actions/checkout references live in different files.

This changes finding IDs, so it has to land before any golden files are
generated for the cross-repo e2e work.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>