### PR TITLE
Stop misreporting non-workflow files as missing permissions

### DIFF
--- a/docs/rules/workflow-permissions.md
+++ b/docs/rules/workflow-permissions.md
@@ -51,6 +51,10 @@ The scanner:
   - top-level `permissions` exists, or
   - every job has its own `permissions`
 - flags the workflow if neither condition is true
+- skips files that define no jobs, since they are not runnable workflows — usually a stray
+  config file in `.github/workflows`. These are reported as an incomplete-scan warning
+  instead, because "this file is not a workflow" is a different problem from "this workflow
+  is missing a permissions block"
 
 This is a structural check only. It verifies that permissions are explicit, not whether each permission set is perfectly minimal.
 

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -653,6 +653,14 @@ func evaluateWorkflowPermissionsRule(facts *ScanFacts) []Finding {
 		if !wf.Valid || hasExplicitPermissions(wf.Workflow) {
 			continue
 		}
+		// A file with no jobs is not a workflow GitHub would ever run — most
+		// often a stray config file parked in .github/workflows. Reporting
+		// "No explicit permissions defined" at high severity misdiagnoses it:
+		// the problem is the file, not its permissions block. Skip it and let
+		// the parse/validity checks own that case.
+		if wf.Workflow != nil && len(wf.Workflow.Jobs) == 0 {
+			continue
+		}
 		msg := ruleMessage(ruleNameWorkflowPermissions, "no-permissions", nil)
 		findings = append(findings, Finding{
 			ID:          fmt.Sprintf("no-permissions-%s", wf.Path),

--- a/internal/scanner/workflow.go
+++ b/internal/scanner/workflow.go
@@ -158,6 +158,17 @@ func parseAndAddWorkflowFile(ctx context.Context, file *github.RepositoryContent
 		if dbg != nil {
 			dbg(repoFull, "workflow parsed OK: "+*file.Path)
 		}
+		// Parses as YAML but defines no jobs, so it is not a workflow GitHub
+		// would ever run — usually a stray config file sitting in
+		// .github/workflows. The workflow rules cannot say anything meaningful
+		// about it, so record it rather than let it drop out of the report
+		// unmentioned.
+		if len(workflow.Jobs) == 0 {
+			c.addWarning("workflow "+*file.Path, "defines no jobs — not a runnable workflow, so workflow rules were not applied")
+			if dbg != nil {
+				dbg(repoFull, "workflow has no jobs: "+*file.Path)
+			}
+		}
 	} else {
 		// Every workflow rule skips files it could not parse. Left unrecorded,
 		// a repository whose workflows all fail to parse produces zero findings

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -258,6 +258,54 @@ func TestEvaluateActionVersionPinningRule_SameActionTwoRefsBothReported(t *testi
 	}
 }
 
+// A file that parses as YAML but defines no jobs is not a runnable workflow —
+// typically a stray config file in .github/workflows. It used to draw a
+// high-severity "No explicit permissions defined", which misdiagnoses the
+// problem: the file is the problem, not its permissions block. It is now
+// reported as an incomplete-scan warning instead, so it is neither misreported
+// nor silently dropped.
+func TestWorkflowWithNoJobs_WarnsInsteadOfClaimingMissingPermissions(t *testing.T) {
+	s, mux := newTestScanner(t, false)
+	handleJSON(mux, "/repos/owner/repo/contents/.github/workflows", []*github.RepositoryContent{{
+		Path: github.Ptr(".github/workflows/config.yml"),
+		Name: github.Ptr("config.yml"),
+	}})
+	handleJSON(mux, "/repos/owner/repo/contents/.github/workflows/config.yml",
+		encodedContent(".github/workflows/config.yml", "some_setting: true\nanother: value\n"))
+
+	collector := newTestFactCollector(s)
+	workflows := collector.collectWorkflowFacts(context.Background(), "owner", "repo", nil)
+
+	if len(collector.warnings) != 1 || !strings.Contains(collector.warnings[0].Detail, "no jobs") {
+		t.Fatalf("warnings = %+v, want one 'no jobs' warning", collector.warnings)
+	}
+
+	findings := evaluateWorkflowPermissionsRule(&ScanFacts{Workflows: workflows})
+	if len(findings) != 0 {
+		t.Fatalf("findings = %+v, want none — a jobless file has no permissions to declare", findings)
+	}
+}
+
+// A real workflow that happens to declare no permissions must still be flagged;
+// the jobless skip above must not swallow the genuine case.
+func TestEvaluateWorkflowPermissionsRule_RealWorkflowStillFlagged(t *testing.T) {
+	content := "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n"
+	workflow := &WorkflowFile{}
+	if err := yaml.Unmarshal([]byte(content), workflow); err != nil {
+		t.Fatalf("yaml.Unmarshal() error: %v", err)
+	}
+
+	findings := evaluateWorkflowPermissionsRule(&ScanFacts{Workflows: []WorkflowFact{{
+		Path:     ".github/workflows/ci.yml",
+		Content:  content,
+		Workflow: workflow,
+		Valid:    true,
+	}}})
+	if len(findings) != 1 {
+		t.Fatalf("findings = %+v, want one no-permissions finding", findings)
+	}
+}
+
 func TestEvaluateWorkflowRules_Integration(t *testing.T) {
 	content := "on: pull_request_target\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
 	workflow := &WorkflowFile{}


### PR DESCRIPTION
R7: hasExplicitPermissions returns false when a file has no permissions block
and no jobs, so a stray config file parked in .github/workflows drew a
high-severity "No explicit permissions defined". That misdiagnoses it -- the
file is the problem, not its permissions block -- and inflates the high-severity
count operators triage on.

The rule now skips jobless files, and the collector raises an incomplete-scan
warning for them instead. Skipping alone would have traded a wrong finding for
no finding at all, which is the failure mode the rest of this stack exists to
remove; the warning keeps the file visible while describing it accurately.

A workflow that does define jobs and genuinely declares no permissions is still
flagged, and there is now a test pinning that so the skip cannot widen.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>