### PR TITLE
Correct rule pages that described behavior the code does not have

### DIFF
--- a/docs/rules/action-version-pinning.md
+++ b/docs/rules/action-version-pinning.md
@@ -48,7 +48,7 @@ There are two extraction paths:
    text, a `uses:` string appearing in a comment or inside a `run:` block is not mistaken
    for a real reference.
 2. **Regex fallback.** When the YAML fails to parse, the scanner scans the raw text with
-   `^\s*-?\s*uses:\s*['"]?([^'"@\s]+)@([^'"@\s]+)['"]?` so an unparseable workflow still
+   `^\s*-?\s*uses:\s*['"]?([^'"@\s]+)@([^'"@\s]+)['"]?` so an unparsable workflow still
    gets pinning coverage instead of being skipped entirely.
 
 Both paths skip:

--- a/docs/rules/action-version-pinning.md
+++ b/docs/rules/action-version-pinning.md
@@ -25,7 +25,8 @@ messages:
 | | |
 |---|---|
 | **Severity** | High |
-| **Check ID** | `action_pinning` |
+| **Rule name** | `workflows/action-version-pinning` |
+| **Aliases** | `action-version-pinning`, `action-pinning`, `pinning` |
 
 ## What it checks
 
@@ -37,12 +38,27 @@ The scanner:
 
 - lists workflow files from `.github/workflows`
 - fetches each file with `GET /repos/{owner}/{repo}/contents/{path}`
-- scans raw workflow text with this regex: `^\s*-?\s*uses:\s*['"]?([^'"@\s]+)@([^'"@\s]+)['"]?`
-- extracts the action name and version from every `uses:` line
-- skips:
-  - local actions starting with `./`
-  - Docker-based actions starting with `docker://`
-- flags any reference whose version is not a 40-character hex SHA
+- extracts every action reference, then flags any whose version is not a full commit SHA
+
+There are two extraction paths:
+
+1. **Parsed workflow (the normal path).** When the YAML parses, the scanner walks the
+   parsed structure and inspects every `jobs.<job_id>.steps[].uses` plus each
+   `jobs.<job_id>.uses` (reusable workflow calls). Because it reads structure rather than
+   text, a `uses:` string appearing in a comment or inside a `run:` block is not mistaken
+   for a real reference.
+2. **Regex fallback.** When the YAML fails to parse, the scanner scans the raw text with
+   `^\s*-?\s*uses:\s*['"]?([^'"@\s]+)@([^'"@\s]+)['"]?` so an unparseable workflow still
+   gets pinning coverage instead of being skipped entirely.
+
+Both paths skip:
+
+- local actions starting with `./`
+- Docker-based actions starting with `docker://`
+
+A reference counts as pinned when its version is a hex SHA of 40 characters (SHA-1) or 64
+characters (SHA-256, accepted for forward compatibility). Anything else — a tag, a branch,
+a short SHA — is treated as unpinned.
 
 Optional config behavior:
 

--- a/docs/rules/actions-can-approve-prs.md
+++ b/docs/rules/actions-can-approve-prs.md
@@ -33,7 +33,8 @@ messages:
 | | |
 |---|---|
 | **Severity** | Medium |
-| **Check ID** | `actions_settings` |
+| **Rule name** | `actions/permissions/workflow/actions-can-approve-prs` |
+| **Aliases** | `actions-can-approve-prs`, `approve-prs` |
 | **Auth required** | Yes |
 | **Minimum fine-grained permission** | `Administration: Read` |
 | **Classic PAT** | `repo` |

--- a/docs/rules/allowed-actions-policy.md
+++ b/docs/rules/allowed-actions-policy.md
@@ -37,7 +37,8 @@ messages:
 | | |
 |---|---|
 | **Severity** | Medium |
-| **Check ID** | `actions_settings` |
+| **Rule name** | `actions/permissions/allowed-actions-policy` |
+| **Aliases** | `allowed-actions-policy`, `allowed-actions` |
 | **Auth required** | Yes |
 | **Minimum fine-grained permission** | `Administration: Read` |
 | **Classic PAT** | `repo` |
@@ -59,9 +60,13 @@ It reads:
 
 Behavior:
 
-- if Actions is disabled (`enabled == false`), the rule returns no finding
+- if Actions is disabled (`enabled == false`), the rule passes — unrestricted third-party
+  actions cannot run in a repository where Actions cannot run at all. This requires GitHub
+  to have actually reported `enabled: false`; a settings read that failed is undetermined,
+  not disabled
 - if `allowed_actions == all`, it creates a medium finding
-- if `allowed_actions == local_only`, it creates an informational "good" finding
+- if `allowed_actions == local_only`, the rule passes — only actions defined inside the
+  repository can run, which blocks third-party public actions entirely
 - if `allowed_actions == selected`, it treats that as the desired setting
 - if Actions is enabled but GitHub reports no `allowed_actions` value at all (observed when
   an org or enterprise policy governs the repository), the rule reports an informational

--- a/docs/rules/default-workflow-permissions.md
+++ b/docs/rules/default-workflow-permissions.md
@@ -37,7 +37,8 @@ messages:
 | | |
 |---|---|
 | **Severity** | High |
-| **Check ID** | `actions_settings` |
+| **Rule name** | `actions/permissions/workflow/default-workflow-permissions` |
+| **Aliases** | `default-workflow-permissions`, `default-permissions` |
 | **Auth required** | Yes |
 | **Minimum fine-grained permission** | `Administration: Read` |
 | **Classic PAT** | `repo` |

--- a/docs/rules/fork-pr-workflow-approval.md
+++ b/docs/rules/fork-pr-workflow-approval.md
@@ -35,7 +35,8 @@ messages:
 | | |
 |---|---|
 | **Severity** | High |
-| **Check ID** | `actions_settings` |
+| **Rule name** | `actions/permissions/fork-pr-contributor-approval` |
+| **Aliases** | `fork-pr-contributor-approval`, `fork-pr-approval` |
 | **Auth required** | Yes |
 | **Minimum fine-grained permission** | `Administration: Read` |
 | **Classic PAT** | `repo` |

--- a/docs/rules/pull-request-target.md
+++ b/docs/rules/pull-request-target.md
@@ -31,7 +31,8 @@ messages:
 | | |
 |---|---|
 | **Severity** | Critical |
-| **Check ID** | `pull_request_target` |
+| **Rule name** | `workflows/pull-request-target` |
+| **Aliases** | `pull-request-target` |
 
 ## What it checks
 

--- a/docs/rules/pull-request-target.md
+++ b/docs/rules/pull-request-target.md
@@ -55,7 +55,11 @@ This rule does not try to prove whether the workflow later checks out untrusted 
 
 ## Why this matters
 
-`pull_request_target` runs in the context of the base branch, not the pull request branch. That means it can access repository secrets and a more trusted token context. If the workflow then checks out or executes code from the pull request, an attacker can exfiltrate secrets or abuse repository access. For that reason, it should never be used in public repositories and is highly discouraged in private repositories.
+`pull_request_target` runs in the context of the base branch, not the pull request branch. That
+means it can access repository secrets and a more trusted token context. If the workflow then
+checks out or executes code from the pull request, an attacker can exfiltrate secrets or abuse
+repository access. For that reason, it should never be used in public repositories and is highly
+discouraged in private repositories.
 
 ## Bad example
 

--- a/docs/rules/workflow-permissions.md
+++ b/docs/rules/workflow-permissions.md
@@ -29,7 +29,8 @@ messages:
 | | |
 |---|---|
 | **Severity** | High |
-| **Check ID** | `workflow_permissions` |
+| **Rule name** | `workflows/workflow-permissions` |
+| **Aliases** | `workflow-permissions`, `permissions` |
 
 ## What it checks
 


### PR DESCRIPTION
R5: seven rule pages carried a "Check ID" row (`action_pinning`,
`actions_settings`, `pull_request_target`, `workflow_permissions`) matching no
string the scanner emits. Real finding IDs look like
`unpinned-<path>-<action>-<ref>` and `dangerous-trigger-<path>`. The row appears
to predate the current ID scheme. Replaced with the rule name and aliases, which
are what a reader actually needs to pass to --rule, and which the three update
rule pages already used.

R4: action-version-pinning presented the line regex as the mechanism. It is the
fallback, used only when a workflow fails to parse; the normal path walks the
parsed structure, which is why a `uses:` inside a comment is not picked up. Both
paths are now described. The page also claimed a 40-character SHA where isSHA
accepts 40 or 64.

R11: allowed-actions-policy said a disabled-Actions repository "returns no
finding" when the rule passes, and described the local_only case as an
"informational good finding" rather than a pass. Both corrected, and the
disabled pass now states that it requires GitHub to have actually reported
enabled:false -- a failed read is undetermined, not disabled.

Docs only; no behavior change.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>