### PR TITLE
Correct the stale actions/checkout version comment in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Checkout
         # persist-credentials required: this job pushes the release tag via `git push origin`
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.3 # zizmor: ignore[artipacked]
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
`release.yml` pinned `actions/checkout@9c091bb2…` with the comment `# v6.0.3`.

That SHA is actually **v7.0.0** — confirmed against GitHub's ref API, and `ci.yml` and `scorecard.yml` already comment the same SHA correctly. `release.yml` was the only outlier.

## Why it matters

zizmor's [`ref-version-mismatch`](https://docs.zizmor.sh/audits/#ref-version-mismatch) audit flags it, so **every PR touching `release.yml` failed the linter on a defect it did not introduce**. Four open Dependabot PRs (#22, #26, #27, #28) are blocked by exactly this.

Dependabot cannot fix it: the SHA is already current, so there is nothing to bump and the comment is never rewritten.

## Verification

- `actionlint` — clean
- `zizmor` — `No findings to report`
- `poutine` — 13 rules, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN