### PR TITLE
Clear the remaining super-linter findings on main

### DIFF
--- a/.chainguard/actions.yaml
+++ b/.chainguard/actions.yaml
@@ -4,4 +4,4 @@ enabled: true
 # Optionally enable automated migration pull requests (defaults to off).
 migrate:
   enabled: true
-  period: "168h"        # reconcile weekly; clamped to a 1-day minimum
+  period: "168h" # reconcile weekly; clamped to a 1-day minimum

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # GitHub Actions Security Assessment
 
-A CLI tool that scans GitHub repositories for Actions security-related misconfigurations. It checks your workflows, repo settings, and dependency tooling against recommended security practices and tells you exactly what to fix.
+A command-line tool that scans GitHub repositories for Actions security-related misconfigurations. It checks your workflows, repo settings, and dependency tooling against recommended security practices and tells you exactly what to fix.
 
-You can scan single repos or entire users and orgs. You can control which rules it runs and the type of output (table, json, or html). Rules have docs and remediation help.
+You can scan single repos or entire users and orgs. You can control which rules it runs and the type of output (`table`, `json`, or `html`). Rules have docs and remediation help.
 
-You can use it as a downloadable CLI, a Docker container, or a GitHub Action. It can do a partical check on a 3rd-party public repository, but for a full settings check it'll need at least read-only admin access, which if your local `gh` cli is logged in, it'll use that to check your repository settings.
+You can use it as a downloadable CLI, a Docker container, or a GitHub Action. It can do a partial check on a third-party public repository, but for a full settings check it'll need at least read-only admin access, which if your local `gh` cli is logged in, it'll use that to check your repository settings.
 
-This tool is only concerned with GitHub Actions security best practices, and goes beyond the workflow yaml to help repo owners, partically open source maintainers, validate that their workflows, settings, and Dependabot/Renovate configs are providing a safe Actions environment.
+This tool is only concerned with GitHub Actions security best practices, and goes beyond the workflow YAML to help repo owners, particularly open source maintainers, validate that their workflows, settings, and Dependabot/Renovate configs are providing a safe Actions environment.
 
 > [!WARNING]
 > Don't run `gasa` as a GitHub Actions workflow on a public repo — the findings report would be public, which is likely the last thing you want for a security report. A future feature will report findings to the GitHub Security tab to keep them private.
@@ -98,7 +98,7 @@ See [Build](#build) below for development commands.
 | `--output` | `batch` | Write the report to this file path (required for `--format html`; optional for `--format json`, which defaults to stdout) |
 | `--concurrency` | `batch` | Number of repos to scan in parallel (default `5`) |
 | `--include-archived` | `batch` | Include archived repos when scanning a whole user or org (skipped by default) |
-| `--input` | `batch` | Path to a file with one `owner/repo` per line (`#` comments and blank lines ignored) |
+| `--input` | `batch` | Path to a file with one `owner/repo` per line (`#` comments and empty lines ignored) |
 
 ### Authentication
 
@@ -188,7 +188,7 @@ Batch mode is the fastest way to assess many repositories at once and roll the r
 |-------|---------|----------|
 | User or org name | `gasa batch bretfisher` | Fetches all of that account's repos (auto-detects user vs org), most-recently-pushed first |
 | Explicit list | `gasa batch owner/repo1,owner/repo2` | Scans only the comma-separated repos |
-| File (`--input`) | `gasa batch --input repos.txt` | Reads one `owner/repo` per line; `#` comments and blank lines are ignored |
+| File (`--input`) | `gasa batch --input repos.txt` | Reads one `owner/repo` per line; `#` comments and empty lines are ignored |
 
 Output depends on `--format`:
 

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -278,7 +278,7 @@ func printIncompleteSummary(results []batchRepoResult) {
 	if repos == 0 {
 		return
 	}
-	fmt.Fprintf(os.Stderr, "\n⚠ %d repositor%s had %d incomplete check(s); findings may be partial. Re-scan affected repos or raise --timeout.\n",
+	fmt.Fprintf(os.Stderr, "\n⚠ %d %s had %d incomplete check(s); findings may be partial. Re-scan affected repos or raise --timeout.\n",
 		repos, pluralRepos(repos), checks)
 }
 
@@ -295,11 +295,14 @@ func countIncomplete(results []batchRepoResult) (repos, checks int) {
 	return repos, checks
 }
 
+// pluralRepos returns the whole noun rather than a suffix. Splitting the word
+// across the format string ("repositor%s") left the literal "repositor" in the
+// source, which codespell reads as a misspelling of "repository".
 func pluralRepos(n int) string {
 	if n == 1 {
-		return "y"
+		return "repository"
 	}
-	return "ies"
+	return "repositories"
 }
 
 // runBatchScans executes scans concurrently and returns ordered results.

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -295,9 +295,10 @@ func countIncomplete(results []batchRepoResult) (repos, checks int) {
 	return repos, checks
 }
 
-// pluralRepos returns the whole noun rather than a suffix. Splitting the word
-// across the format string ("repositor%s") left the literal "repositor" in the
-// source, which codespell reads as a misspelling of "repository".
+// pluralRepos returns the whole noun rather than just its plural suffix.
+// Previously the caller emitted the stem inline and this returned only the
+// ending, which left a truncated word in the source that spell checkers
+// reasonably flagged as a typo.
 func pluralRepos(n int) string {
 	if n == 1 {
 		return "repository"

--- a/docs/rules/update-tool-actions-cooldown.md
+++ b/docs/rules/update-tool-actions-cooldown.md
@@ -107,7 +107,7 @@ updates:
 }
 ```
 
-**Renovate — scoped to github-actions via packageRules:**
+**Renovate — scoped to `github-actions` via packageRules:**
 
 ```json
 {

--- a/docs/rules/update-tool-configuration.md
+++ b/docs/rules/update-tool-configuration.md
@@ -156,7 +156,7 @@ updates:
 }
 ```
 
-**Renovate (implicit — auto-detects all managers including github-actions):**
+**Renovate (implicit — auto-detects all managers including `github-actions`):**
 
 ```json
 {


### PR DESCRIPTION
Pushes to `main` lint the **whole codebase**, unlike PRs which only check changed files. These pre-existing issues surfaced once the Phase A stack landed.

## codespell

- `README.md`: `partical` → `partial`
- `README.md`: `partically` → **`particularly`**, not codespell's suggested `partially` — "help repo owners, partically open source maintainers" clearly means *particularly*
- `cmd/batch.go`: `printIncompleteSummary` split a word across its format string (`"%d repositor%s"`) with `pluralRepos` returning `y`/`ies`, leaving the literal `repositor` in the source. `pluralRepos` now returns the whole noun — better code, and removes the false positive without suppressing anything

## textlint terminology

- `CLI tool` → `command-line tool`, `3rd-party` → `third-party`, `yaml` → `YAML` (the language), `blank lines` → `empty lines`
- The output formats in the intro are values passed to `--format`, so they're marked as **code** rather than capitalized — `--format JSON` would be wrong
- Two bare `github-actions` manager names in rule doc prose get backticks; the other occurrences are in front matter or code fences, which textlint already skips

## prettier

- Comment alignment in `.chainguard/actions.yaml`

## Verification

`make test` green, `make build` OK, prettier clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN