### PR TITLE
Handle private-repo fork-PR approval and stop overwriting finding severity

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1293,12 +1293,45 @@ Phase C cannot begin until this stack is merged: PRs #34 and #39 change rule out
 
 7. R20's "Bad example" in `update-tool-actions-pinning.md` (teaches a config that is actually correct), R4 (rule 2 describes only the fallback path), R11 (rule 4 contradicts the code), R5 (stale "Check ID" row, sweep all 10 pages)
 
-**Phase C — fixtures.** After the code is frozen.
+**Phase C — fixtures. In progress.**
 
-8. **R15** — set `can_approve_pull_request_reviews: true` on `gasa-fail`; last settings rule it does not fail
-9. **R18 + R21** — create `gasa-fail-private` with the R22-revised config shape, **re-scope `E2E_REPO_PAT` to include it**, and probe all four settings endpoints on a private repo before writing its manifest
+8. ~~**R15** — set `can_approve_pull_request_reviews: true` on `gasa-fail`~~ **Done 2026-08-11.** `gasa-fail` now fails 8 of 10 rules, which is every rule it structurally can; only rules 9 and 10 remain, and those are what `gasa-fail-private` exists for
+9. ~~**R18 + R21** — create `gasa-fail-private`~~ **Done 2026-08-11.** Private repo created with
+   Dependabot scoped to `docker` only (plus a real `Dockerfile` so that ecosystem is valid), Renovate
+   `{"extends": ["config:recommended"]}`, one deliberately correct SHA-pinned workflow, and hardened
+   Actions settings. Verified live: 10 of 10 rules report, and exactly rules 9 and 10 fail. Two code
+   defects were found in the process — see P1 and P2 below. **Still outstanding: re-scope
+   `E2E_REPO_PAT` to include this repository** (see below)
 10. Optional: good Renovate config on `gasa-pass`, which doubles as the live regression test for R20
-11. Hygiene: make fixture workflow `run:` steps inert; decide the Dependabot-churn question (R2, R14)
+11. Hygiene: make fixture workflow `run:` steps inert (`gasa-fail` only; the new fixture already is)
+
+Decided 2026-08-11: **Dependabot is not suppressed on the fixture repositories.** Churn is accepted and `fixtures-apply` reverts it, which needs no extra setup and self-heals. This closes R2 and R14.
+
+**Blocking Phase D — `E2E_REPO_PAT` must be re-scoped.** The token currently grants access to
+`gasa-pass` and `gasa-fail` only. Add `gasa-fail-private`, keeping `Contents: Read` and
+`Administration: Read`. On a private repository `Contents: Read` is load-bearing rather than a
+formality. Without it the e2e job fails with a 404 that reads like a missing repository rather than
+a permissions problem. This is a manual step in the GitHub UI; fine-grained PAT scopes are not
+editable through the API.
+
+#### Defects found while building the private fixture
+
+Both were discovered only by pointing the scanner at a real private repository, which is precisely the class of bug mocked tests cannot reach.
+
+- **P1 — FIX-CODE: fork-PR approval reported as unverified on every private repository.** `GET
+  /actions/permissions/fork-pr-contributor-approval` answers **422** on private repos with "Fork PR
+  approval is not allowed for private repositories". 422 is neither an access denial nor a transient
+  failure, so it fell to the catch-all branch and produced both an undetermined finding and an
+  incomplete-scan warning — flagging a control that cannot be misconfigured because it does not exist
+  there. Now recognised as a distinct not-applicable state that passes with its own message and raises
+  no warning
+- **P2 — FIX-CODE: `applyRuleConfig` discarded every finding's own severity.** It stamped the rule's
+  severity onto all findings unconditionally, so the deliberate `info` on the access and "could not
+  determine" findings was overwritten with the rule's — a gap in coverage rendered as a high-severity
+  vulnerability, inflating the counts operators triage on. Now only an explicit user override replaces
+  a finding's chosen severity; a finding that sets none still inherits the rule default. This bug
+  predates the audit and affected the existing `settings-check-failed` and
+  `settings-check-unavailable` findings too
 
 **Phase D — harness.** Capture fixtures, build `fixtures-verify` / `fixtures-apply`, generate goldens, add the coverage-matrix test, add `.github/workflows/e2e.yml`.
 
@@ -1306,17 +1339,12 @@ Phase C cannot begin until this stack is merged: PRs #34 and #39 change rule out
 
 ### Open decisions
 
-- should the e2e job also assert exit codes and human table output, or only the scanner API? In other
-  words: call the scanner's Go API directly and check the findings it returns, or run the real `gasa`
-  binary and check what a user sees. API-only gives clearer failures; running the binary also covers
-  CLI wiring (flag parsing, token resolution) that the API path skips. Recommendation: both, weighted
-  — the API for the 10-rule matrix, plus one small test that runs the binary end to end
-- whether to suppress Dependabot on the fixture repos or let `fixtures-apply` revert its churn.
-  `gasa-pass` currently has five open Dependabot PRs proposing action bumps; if one merges, the repo
-  no longer matches the checked-in fixture and the drift check fires. Either set
-  `open-pull-requests-limit: 0` there to freeze it, or leave it and let `fixtures-apply` push the
-  intended state back. The second needs no setup and self-heals; the first means fewer surprise
-  failures
+- ~~should the e2e job assert the scanner API or the CLI binary?~~ **Resolved 2026-08-11: both.** The
+  scanner API carries the 10-rule coverage matrix because its failures point straight at scanner
+  behavior, and a smaller set of assertions drives the real `gasa` binary to cover the CLI wiring the
+  API path skips — flag parsing, `--no-config`, token resolution, output format, and exit code
+- ~~whether to suppress Dependabot on the fixture repos~~ **Resolved 2026-08-11: not suppressed.**
+  Churn is accepted and `fixtures-apply` reverts it, which needs no extra setup and self-heals
 - R6, R8, R16 have moved to Phase 13 and are decided there, not here
 
 Result needed:

--- a/docs/rules/fork-pr-workflow-approval.md
+++ b/docs/rules/fork-pr-workflow-approval.md
@@ -23,6 +23,11 @@ messages:
     description: >-
       GitHub Actions are disabled for this repository, so fork pull request
       workflows cannot run.
+  pass-not-applicable:
+    title: Fork pull request workflow approval does not apply to this repository
+    description: >-
+      GitHub does not offer this setting for private repositories, so there is no
+      fork pull request approval policy to weaken.
   pass-all-external:
     title: Fork pull request workflows require full external approval
     description: >-

--- a/internal/scanner/facts.go
+++ b/internal/scanner/facts.go
@@ -46,6 +46,17 @@ type ActionsSettingsFacts struct {
 	DefaultWorkflowPermissions *github.DefaultWorkflowPermissionRepository
 	ForkPRContributorApproval  *github.ContributorApprovalPermissions
 
+	// ForkPRApprovalNotApplicable is set when GitHub reports that fork-PR
+	// approval does not exist for this repository at all. Private repositories
+	// answer the endpoint with 422 "Fork PR approval is not allowed for private
+	// repositories".
+	//
+	// This is deliberately distinct from Undetermined: the setting was not
+	// unreadable, it has no meaning here. Reporting it as unreadable produced a
+	// finding and an incomplete-scan warning on every private repository scan,
+	// for a control that cannot be misconfigured because it does not exist.
+	ForkPRApprovalNotApplicable bool
+
 	// Undetermined records settings the scanner tried to read but could not,
 	// keyed by the constants below and holding a human-readable cause.
 	//

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -387,6 +387,9 @@ func forkPRApprovalSuccessFinding(ruleName, severity string, facts *ScanFacts) *
 		}
 		return successMessage(ruleName, severity, "Repository Actions settings", "pass-disabled", nil)
 	}
+	if facts.ActionsSettings.ForkPRApprovalNotApplicable {
+		return successMessage(ruleName, severity, "Repository Actions settings", "pass-not-applicable", nil)
+	}
 	policy := facts.ActionsSettings.ForkPRContributorApproval
 	if policy == nil || policy.ApprovalPolicy != forkPRApprovalAllExternal {
 		return nil
@@ -757,6 +760,11 @@ func evaluateForkPRContributorApprovalRule(facts *ScanFacts) []Finding {
 	findings := make([]Finding, 0)
 	findings = appendSettingsAccessFinding(findings, facts)
 
+	// Nothing to flag where the control does not exist.
+	if facts.ActionsSettings.ForkPRApprovalNotApplicable {
+		return findings
+	}
+
 	if undetermined := undeterminedFindingFor(facts, ruleNameForkPRContributorApproval, settingForkPRApproval); undetermined != nil {
 		return append(findings, *undetermined)
 	}
@@ -791,12 +799,28 @@ func evaluateUpdateToolActionsPinningRule(facts *ScanFacts) []Finding {
 }
 
 func applyRuleConfig(findings []Finding, r rule, cfg *Config) []Finding {
+	// Only a user's explicit severity override replaces what a finding chose for
+	// itself. Stamping the rule's default severity onto every finding discarded
+	// the deliberate `info` on the access and "could not determine" findings, so
+	// a check that merely could not be evaluated was reported at the full
+	// severity of the rule it belongs to — a coverage hole rendered as a
+	// high-severity vulnerability.
+	override := ""
+	if cfg != nil {
+		if s := normalizeSeverity(cfg.severityOverride(r.Name)); isValidSeverity(s) {
+			override = s
+		}
+	}
+
 	for i := range findings {
 		findings[i].Rule = r.Name
 		findings[i].Category = r.Category
 		findings[i].DocURL = r.DocURL()
-		if override := effectiveRuleSeverity(r, cfg); override != "" {
+		switch {
+		case override != "":
 			findings[i].Severity = override
+		case findings[i].Severity == "":
+			findings[i].Severity = r.Severity
 		}
 	}
 	return findings

--- a/internal/scanner/settings.go
+++ b/internal/scanner/settings.go
@@ -28,6 +28,18 @@ func isAccessDenied(resp *github.Response) bool {
 	}
 }
 
+// isForkPRApprovalUnsupported reports whether GitHub answered the fork-PR
+// contributor approval endpoint with "this setting does not apply here".
+//
+// Private repositories return 422 with "Fork PR approval is not allowed for
+// private repositories". That is a determinate answer about the repository, not
+// a failure to read it, so it must not be treated as an access denial or a
+// transient error — both of those would report a control that cannot exist as
+// unverified.
+func isForkPRApprovalUnsupported(resp *github.Response) bool {
+	return resp != nil && resp.Response != nil && resp.StatusCode == http.StatusUnprocessableEntity
+}
+
 func (c *factCollector) collectActionsSettingsFacts(ctx context.Context, owner, repo string, dbg DebugLogger) ActionsSettingsFacts {
 	facts := ActionsSettingsFacts{}
 	repoFull := owner + "/" + repo
@@ -180,6 +192,11 @@ func fetchAuthenticatedActionsSettings(ctx context.Context, c *factCollector, ow
 		facts.ForkPRContributorApproval = policy
 		if dbg != nil {
 			dbg(repoFull, "fork-pr-approval: policy="+policy.ApprovalPolicy)
+		}
+	case isForkPRApprovalUnsupported(resp):
+		facts.ForkPRApprovalNotApplicable = true
+		if dbg != nil {
+			dbg(repoFull, "fork-pr-approval: not applicable to this repository (HTTP 422)")
 		}
 	case isAccessDenied(resp):
 		facts.markUndetermined(settingForkPRApproval, fmt.Sprintf("GitHub returned %d — the token cannot read this setting", resp.StatusCode))

--- a/internal/scanner/settings_test.go
+++ b/internal/scanner/settings_test.go
@@ -483,3 +483,67 @@ func collectAndEvaluateActionsSettings(t *testing.T, s *Scanner) []Finding {
 	findings = append(findings, evaluateForkPRContributorApprovalRule(facts)...)
 	return dedupeFindings(findings)
 }
+
+// GitHub answers the fork-PR approval endpoint with 422 on private repositories
+// ("Fork PR approval is not allowed for private repositories"). That is a
+// determinate answer about the repository, not a failed read, so it must not
+// produce an undetermined finding or an incomplete-scan warning — doing so
+// reported a control that cannot exist as unverified on every private scan.
+func TestForkPRApproval_UnsupportedOnPrivateRepoIsNotApplicable(t *testing.T) {
+	s, mux := newTestScanner(t, true)
+	handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "selected"})
+	handleJSON(mux, "/repos/owner/repo/actions/permissions/workflow", map[string]any{"default_workflow_permissions": "read", "can_approve_pull_request_reviews": false})
+	mux.HandleFunc("/repos/owner/repo/actions/permissions/fork-pr-contributor-approval", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		if _, err := w.Write([]byte(`{"message":"Fork PR approval is not allowed for private repositories."}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	})
+
+	collector := newTestFactCollector(s)
+	facts := &ScanFacts{ActionsSettings: collector.collectActionsSettingsFacts(context.Background(), "owner", "repo", nil)}
+
+	if !facts.ActionsSettings.ForkPRApprovalNotApplicable {
+		t.Fatal("expected the 422 to be recorded as not applicable")
+	}
+	if len(collector.warnings) != 0 {
+		t.Fatalf("a setting that does not exist must not mark the scan incomplete, got %+v", collector.warnings)
+	}
+	if findings := evaluateForkPRContributorApprovalRule(facts); len(findings) != 0 {
+		t.Fatalf("findings = %+v, want none", findings)
+	}
+
+	success := forkPRApprovalSuccessFinding(ruleNameForkPRContributorApproval, SeverityHigh, facts)
+	if success == nil {
+		t.Fatal("expected a success finding explaining the setting does not apply")
+	}
+	if !strings.Contains(success.Title, "does not apply") {
+		t.Fatalf("success title = %q, want it to say the setting does not apply", success.Title)
+	}
+}
+
+// A finding that deliberately sets its own severity must keep it. Stamping the
+// rule's severity over every finding reported "could not determine" — a gap in
+// coverage — at the full severity of the rule, inflating the counts operators
+// trust.
+func TestApplyRuleConfig_PreservesDeliberateFindingSeverity(t *testing.T) {
+	r := rule{RuleInfo: RuleInfo{Name: ruleNameForkPRContributorApproval, Severity: SeverityHigh, Category: categorySettings}}
+
+	got := applyRuleConfig([]Finding{{ID: "undetermined-x", Severity: SeverityInfo}}, r, nil)
+	if got[0].Severity != SeverityInfo {
+		t.Fatalf("severity = %q, want info to survive", got[0].Severity)
+	}
+
+	// A finding that sets nothing still inherits the rule's severity.
+	got = applyRuleConfig([]Finding{{ID: "plain"}}, r, nil)
+	if got[0].Severity != SeverityHigh {
+		t.Fatalf("severity = %q, want the rule default when the finding sets none", got[0].Severity)
+	}
+
+	// An explicit user override still wins.
+	cfg := &Config{Overrides: []RuleOverride{{Rule: ruleNameForkPRContributorApproval, Severity: "low"}}}
+	got = applyRuleConfig([]Finding{{ID: "undetermined-x", Severity: SeverityInfo}}, r, cfg)
+	if got[0].Severity != SeverityLow {
+		t.Fatalf("severity = %q, want the config override to win", got[0].Severity)
+	}
+}


### PR DESCRIPTION
Two defects found while building the `gasa-fail-private` test fixture for Phase C. Both required pointing the scanner at a **real private repository** — neither is reachable by the mocked suite.

## P1 — fork-PR approval reported as unverified on every private repo

`GET /actions/permissions/fork-pr-contributor-approval` answers **422** on private repositories:

> Fork PR approval is not allowed for private repositories.

422 is neither an access denial (403/404) nor a transient failure, so it fell to the catch-all branch and produced **both** an undetermined finding **and** an incomplete-scan warning — flagging a control as unverified that cannot be misconfigured because it does not exist there.

Now recognised as a distinct not-applicable state: the rule passes with its own message and raises no warning.

## P2 — `applyRuleConfig` discarded every finding's own severity

It stamped the rule's severity onto all findings unconditionally, overwriting the deliberate `info` on the access and "could not determine" findings. A **gap in coverage was rendered as a high-severity vulnerability**, inflating the counts operators triage on.

Only an explicit user override now replaces a finding's chosen severity; a finding that sets none still inherits the rule default.

This one predates the audit — it also affected the existing `settings-check-failed` and `settings-check-unavailable` findings.

## Verified against all three fixtures

| Repo | Result |
|---|---|
| `gasa-pass` | 10/10 rules passing |
| `gasa-fail` | 8 failing, of the 8 it structurally can |
| `gasa-fail-private` | 10/10 reporting, exactly rules 9 + 10 failing, no incomplete warning |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN