### PR TITLE
Add the end-to-end workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,75 @@
+---
+name: E2E
+
+# Scans the three real fixture repositories and asserts what gasa reports.
+# Kept separate from ci.yml because it has a different trust model, a different
+# credential, and a different failure meaning.
+#
+# Deliberately NOT triggered by pull_request. This job holds a cross-repository
+# PAT, and a pull request in a Go repository runs attacker-controlled code --
+# `go test` executes whatever the branch added. Any PR-triggered job holding a
+# PAT is an exfiltration path, and it does not take a fork to exploit. The
+# consequence is accepted: rule regressions are caught on main rather than in
+# the PR that introduces them, and `make test-e2e` is the cheap pre-merge check.
+on:
+  push:
+    branches: [main]
+    # Only paths that can change what a scan reports.
+    paths:
+      - "**/*.go"
+      - go.mod
+      - go.sum
+      - docs/rules/**
+      - testdata/e2e/**
+      - .github/workflows/e2e.yml
+  # Catches GitHub changing its own API behaviour, which is a primary reason
+  # this suite exists and which no code change would otherwise reveal.
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Reset permissions to none at the workflow level; the job grants its own.
+permissions: {}
+
+jobs:
+  scan:
+    name: Scan Fixtures
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # The PAT is an environment secret, so only a job declaring this
+    # environment can reach it. That keeps it out of reach of every other
+    # workflow in this repository.
+    environment: e2e-fixtures
+
+    permissions:
+      # Only to clone this repository. GITHUB_TOKEN is not the credential doing
+      # the scanning; it cannot read the fixture repositories at all.
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      # Runs before the assertions so drift is reported as drift, rather than
+      # surfacing later as a rule regression that is not one.
+      - name: Verify fixture repositories match the checkout
+        env:
+          GITHUB_TOKEN: ${{ secrets.E2E_REPO_PAT }}
+        run: make fixtures-verify
+
+      - name: Run end-to-end scans
+        env:
+          GITHUB_TOKEN: ${{ secrets.E2E_REPO_PAT }}
+        run: make test-e2e

--- a/PLAN.md
+++ b/PLAN.md
@@ -1333,7 +1333,32 @@ Both were discovered only by pointing the scanner at a real private repository, 
   predates the audit and affected the existing `settings-check-failed` and
   `settings-check-unavailable` findings too
 
-**Phase D — harness.** Capture fixtures, build `fixtures-verify` / `fixtures-apply`, generate goldens, add the coverage-matrix test, add `.github/workflows/e2e.yml`.
+**Phase D — harness. Complete 2026-08-11**, in three pull requests: fixture tooling, the test suite, and
+the workflow.
+
+- `tools/fixtures` declares each fixture repository's content and Actions settings under
+  `testdata/e2e/fixtures/`, with `verify` (read-only, the only mode CI runs), `apply` (additive, never
+  deletes) and `capture` modes, wired to `make fixtures-verify` / `fixtures-apply` / `fixtures-capture`
+- `test/e2e` scans all three repositories behind an `e2e` build tag, asserting the scanner API against
+  golden files and separately driving the real binary for the CLI wiring the API path skips
+- `TestEveryRuleHasPassAndFailCoverage` enforces that every registered rule passes in `gasa-pass` and
+  fails in at least one fail fixture, so adding a rule without fixtures becomes a build failure
+- `.github/workflows/e2e.yml` runs on pushes to `main` (path-filtered), a daily schedule, and manual
+  dispatch — never on `pull_request`, since the job holds a cross-repository PAT and a PR runs
+  attacker-controlled code. Linted clean with actionlint, zizmor and poutine
+
+Two further defects were found while building it, both fixed in the same pull requests:
+
+- **P3 — the cooldown and pinning rules went silent when no update tool covered `github-actions`.**
+  Neither a finding nor a success, so the check vanished from the report — indistinguishable from a
+  clean pass. True of `gasa-fail` for both rules. They now report not-applicable explicitly, matching
+  the treatment private-repo fork-PR approval received in P1. All three fixtures now report all ten
+  rules
+- **P4 — the first version of the e2e suite passed while comparing empty results against empty
+  goldens.** The rule registry is built from `docs/rules` front matter and populated by the binary at
+  startup, so a package importing the scanner directly registers no rules and every scan returns
+  nothing. `TestMain` now refuses to run on an empty registry, and a scan reporting fewer findings
+  than there are registered rules is a hard failure
 
 **Phase E — deferred.** R17 (nine Renovate 404 probes per scan) is an efficiency item that blocks nothing. The three new-rule candidates surfaced by this audit (R6, R8, R16) have moved to Phase 13.
 


### PR DESCRIPTION
Third of three PRs building the Phase 12 harness. **Stacked on #52.**

Runs `make fixtures-verify` then `make test-e2e` against the three real fixture repositories. Kept separate from `ci.yml` because it has a different trust model, credential, and failure meaning.

## The important decision: no `pull_request` trigger

This job holds a cross-repository PAT, and a pull request in a Go repository runs **attacker-controlled code** — `go test` executes whatever the branch added. Any PR-triggered job holding a PAT is an exfiltration path, and it does not take a fork to exploit.

The consequence is accepted and written into the workflow: rule regressions are caught on `main`, not in the PR that introduces them. `make test-e2e` is the cheap pre-merge check.

Triggers are pushes to `main` (path-filtered to what can change a scan), a **daily schedule**, and manual dispatch. The schedule is what catches GitHub changing its own API behaviour — a primary reason this suite exists, and something no code change would reveal.

## Credential handling

- PAT is an **environment secret**, so only a job declaring `environment: e2e-fixtures` can reach it
- Exposed **per-step**, never job-wide
- `GITHUB_TOKEN` gets `contents: read` purely to clone this repo; it cannot read the fixture repositories at all
- Workflow-level `permissions: {}`

`fixtures-verify` runs **before** the assertions, so drift is reported as drift rather than surfacing as a rule regression that isn't one.

## Linting

| Tool | Result |
|---|---|
| actionlint | clean |
| zizmor | `No findings to report` |
| poutine | 13 rules, 0 failures |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN