### PR TITLE
Add the end-to-end suite, golden files, coverage matrix, and workflow

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -1,5 +1,11 @@
 # Ref https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 version: "2"
+run:
+  # test/e2e contains only files behind the `e2e` build tag, so without it that
+  # package has no Go files and golangci-lint fails typechecking outright.
+  # Setting the tag lints the end-to-end suite rather than skipping it.
+  build-tags:
+    - e2e
 linters:
   enable:
     - goconst

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,75 @@
+---
+name: E2E
+
+# Scans the three real fixture repositories and asserts what gasa reports.
+# Kept separate from ci.yml because it has a different trust model, a different
+# credential, and a different failure meaning.
+#
+# Deliberately NOT triggered by pull_request. This job holds a cross-repository
+# PAT, and a pull request in a Go repository runs attacker-controlled code --
+# `go test` executes whatever the branch added. Any PR-triggered job holding a
+# PAT is an exfiltration path, and it does not take a fork to exploit. The
+# consequence is accepted: rule regressions are caught on main rather than in
+# the PR that introduces them, and `make test-e2e` is the cheap pre-merge check.
+on:
+  push:
+    branches: [main]
+    # Only paths that can change what a scan reports.
+    paths:
+      - "**/*.go"
+      - go.mod
+      - go.sum
+      - docs/rules/**
+      - testdata/e2e/**
+      - .github/workflows/e2e.yml
+  # Catches GitHub changing its own API behaviour, which is a primary reason
+  # this suite exists and which no code change would otherwise reveal.
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Reset permissions to none at the workflow level; the job grants its own.
+permissions: {}
+
+jobs:
+  scan:
+    name: Scan Fixtures
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # The PAT is an environment secret, so only a job declaring this
+    # environment can reach it. That keeps it out of reach of every other
+    # workflow in this repository.
+    environment: e2e-fixtures
+
+    permissions:
+      # Only to clone this repository. GITHUB_TOKEN is not the credential doing
+      # the scanning; it cannot read the fixture repositories at all.
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      # Runs before the assertions so drift is reported as drift, rather than
+      # surfacing later as a rule regression that is not one.
+      - name: Verify fixture repositories match the checkout
+        env:
+          GITHUB_TOKEN: ${{ secrets.E2E_REPO_PAT }}
+        run: make fixtures-verify
+
+      - name: Run end-to-end scans
+        env:
+          GITHUB_TOKEN: ${{ secrets.E2E_REPO_PAT }}
+        run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build clean test cover deps fmt vet lint fixtures-verify fixtures-apply fixtures-capture
+.PHONY: run build clean test test-e2e e2e-update cover deps fmt vet lint fixtures-verify fixtures-apply fixtures-capture
 
 # Run the CLI
 run:
@@ -39,7 +39,19 @@ vet:
 
 # Lint via golangci-lint (install: brew install golangci-lint)
 lint:
-	golangci-lint run -c .github/linters/.golangci.yaml ./...
+	golangci-lint run -c .github/linters/.golangci.yml ./...
+
+# Run the end-to-end suite against the real fixture repositories. Behind a build
+# tag so `make test` cannot reach the network even by accident. Needs a token
+# with Contents: Read and Administration: Read on all three fixture repos.
+test-e2e:
+	go test -tags=e2e -count=1 -timeout=10m ./test/e2e/...
+
+# Regenerate the golden files from the current scan results. Deliberately
+# separate from test-e2e: goldens must never update as a side effect of running
+# the suite, or a regression would quietly rewrite its own expectations.
+e2e-update:
+	go test -tags=e2e -count=1 -timeout=10m ./test/e2e/... -run TestScanMatchesGolden -update
 
 # --- End-to-end test fixture repositories -----------------------------------
 # The e2e suite scans three real repositories (gasa-pass, gasa-fail,

--- a/PLAN.md
+++ b/PLAN.md
@@ -1333,7 +1333,32 @@ Both were discovered only by pointing the scanner at a real private repository, 
   predates the audit and affected the existing `settings-check-failed` and
   `settings-check-unavailable` findings too
 
-**Phase D — harness.** Capture fixtures, build `fixtures-verify` / `fixtures-apply`, generate goldens, add the coverage-matrix test, add `.github/workflows/e2e.yml`.
+**Phase D — harness. Complete 2026-08-11**, in three pull requests: fixture tooling, the test suite, and
+the workflow.
+
+- `tools/fixtures` declares each fixture repository's content and Actions settings under
+  `testdata/e2e/fixtures/`, with `verify` (read-only, the only mode CI runs), `apply` (additive, never
+  deletes) and `capture` modes, wired to `make fixtures-verify` / `fixtures-apply` / `fixtures-capture`
+- `test/e2e` scans all three repositories behind an `e2e` build tag, asserting the scanner API against
+  golden files and separately driving the real binary for the CLI wiring the API path skips
+- `TestEveryRuleHasPassAndFailCoverage` enforces that every registered rule passes in `gasa-pass` and
+  fails in at least one fail fixture, so adding a rule without fixtures becomes a build failure
+- `.github/workflows/e2e.yml` runs on pushes to `main` (path-filtered), a daily schedule, and manual
+  dispatch — never on `pull_request`, since the job holds a cross-repository PAT and a PR runs
+  attacker-controlled code. Linted clean with actionlint, zizmor and poutine
+
+Two further defects were found while building it, both fixed in the same pull requests:
+
+- **P3 — the cooldown and pinning rules went silent when no update tool covered `github-actions`.**
+  Neither a finding nor a success, so the check vanished from the report — indistinguishable from a
+  clean pass. True of `gasa-fail` for both rules. They now report not-applicable explicitly, matching
+  the treatment private-repo fork-PR approval received in P1. All three fixtures now report all ten
+  rules
+- **P4 — the first version of the e2e suite passed while comparing empty results against empty
+  goldens.** The rule registry is built from `docs/rules` front matter and populated by the binary at
+  startup, so a package importing the scanner directly registers no rules and every scan returns
+  nothing. `TestMain` now refuses to run on an empty registry, and a scan reporting fewer findings
+  than there are registered rules is a hard failure
 
 **Phase E — deferred.** R17 (nine Renovate 404 probes per scan) is an efficiency item that blocks nothing. The three new-rule candidates surfaced by this audit (R6, R8, R16) have moved to Phase 13.
 

--- a/docs/rules/update-tool-actions-cooldown.md
+++ b/docs/rules/update-tool-actions-cooldown.md
@@ -22,6 +22,11 @@ messages:
 
       Renovate (renovate.json / .github/renovate.json) — add globally or in a packageRule:
         { "minimumReleaseAge": "7 days" }
+  pass-not-applicable:
+    title: No GitHub Actions updates to apply a cooldown to
+    description: >-
+      No configured update tool covers the github-actions ecosystem, so there
+      are no action updates for a cooldown to delay.
   pass:
     title: GitHub Actions update cooldown is configured
     description: >-

--- a/docs/rules/update-tool-actions-pinning.md
+++ b/docs/rules/update-tool-actions-pinning.md
@@ -28,6 +28,11 @@ messages:
       Or add a github-actions entry to .github/dependabot.yml — Dependabot
       preserves whatever reference style your workflows already use, so it keeps
       SHAs current on an already-pinned repository.
+  pass-not-applicable:
+    title: No GitHub Action SHAs for an update tool to maintain
+    description: >-
+      No configured update tool covers the github-actions ecosystem, so there
+      are no action references for one to keep pinned.
   pass:
     title: Update tool will keep GitHub Action commit SHAs current
     description: >-

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -435,25 +435,39 @@ func updateToolActionsCooldownSuccessFinding(ruleName, severity string, facts *S
 	depOK := !dep.Missing && dep.Invalid == nil && dep.Config != nil
 	renOK := !ren.Missing && ren.Invalid == nil && ren.Config != nil
 
+	// No update tool at all: there is no cooldown to set. update-tool-configuration
+	// reports the absence; this rule says so rather than going quiet.
 	if !depOK && !renOK {
-		return nil
+		return successMessage(ruleName, severity, "Dependency update tool configuration", "pass-not-applicable", nil)
 	}
 
-	depHasCooldown := depOK && dependabotActionsCooldownConfigured(dep.Config)
-	renHasCooldown := renOK && renovateCooldownConfigured(ren.Config)
-
-	if !depHasCooldown && !renHasCooldown {
-		return nil
+	if depOK && dependabotActionsCooldownConfigured(dep.Config) ||
+		renOK && renovateCooldownConfigured(ren.Config) {
+		return successMessage(ruleName, severity, "Dependency update tool configuration", "pass", nil)
 	}
 
-	return successMessage(ruleName, severity, "Dependency update tool configuration", "pass", nil)
+	// Reaching here with no cooldown means the rule already emitted its finding,
+	// unless nothing covers github-actions — in which case a cooldown for action
+	// updates is moot and the rule must still report that, not vanish.
+	coversActions := depOK && dependabotCoversActions(dep.Config) ||
+		renOK && renovateCoversActions(ren.Config)
+	if !coversActions {
+		return successMessage(ruleName, severity, "Dependency update tool configuration", "pass-not-applicable", nil)
+	}
+	return nil
 }
 
 func updateToolActionsPinningSuccessFinding(ruleName, severity string, facts *ScanFacts) *Finding {
-	if actionsPinningState(facts.Dependabot, facts.Renovate) != actionsPinningConfigured {
+	switch actionsPinningState(facts.Dependabot, facts.Renovate) {
+	case actionsPinningConfigured:
+		return successMessage(ruleName, severity, "Dependency update tool configuration", "pass", nil)
+	case actionsPinningNotApplicable:
+		// Nothing covers github-actions, so there are no action SHAs for an
+		// update tool to keep current. Say so rather than reporting nothing.
+		return successMessage(ruleName, severity, "Dependency update tool configuration", "pass-not-applicable", nil)
+	default:
 		return nil
 	}
-	return successMessage(ruleName, severity, "Dependency update tool configuration", "pass", nil)
 }
 
 func ruleCategory(ruleName string) string {

--- a/internal/scanner/updates_test.go
+++ b/internal/scanner/updates_test.go
@@ -485,17 +485,36 @@ func TestEvaluateUpdateToolActionsPinning_DependabotActionsEntryPasses(t *testin
 	}
 }
 
-// No tool covers github-actions, so there is nothing to keep pinned. The rule is
-// not applicable and must emit neither a finding nor a success —
-// update-tool-configuration reports the missing coverage instead.
-func TestEvaluateUpdateToolActionsPinning_NoActionsCoverageIsNotApplicable(t *testing.T) {
+// No tool covers github-actions, so there is nothing to keep pinned. The rule
+// must still report that explicitly: emitting nothing at all would make the
+// check vanish from the report, which in every output format is
+// indistinguishable from a clean pass.
+func TestEvaluateUpdateToolActionsPinning_NoActionsCoverageReportsNotApplicable(t *testing.T) {
 	facts := &ScanFacts{Dependabot: dependabotFactsWithEcosystem("docker")}
 
 	if findings := evaluateUpdateToolActionsPinningFacts(facts); len(findings) != 0 {
 		t.Fatalf("findings = %+v, want none", findings)
 	}
-	if pinningSuccess(t, facts) {
-		t.Fatal("expected no success finding when no tool covers github-actions")
+	success := updateToolActionsPinningSuccessFinding(ruleNameUpdateToolActionsPinning, SeverityMedium, facts)
+	if success == nil {
+		t.Fatal("expected a not-applicable success finding; a silent rule reads as a clean pass")
+	}
+	if !strings.Contains(success.Title, "No GitHub Action SHAs") {
+		t.Fatalf("success title = %q, want the not-applicable message", success.Title)
+	}
+}
+
+// Same contract for the cooldown rule: no actions coverage means no action
+// updates to delay, and the rule says so rather than going quiet.
+func TestEvaluateUpdateToolActionsCooldown_NoActionsCoverageReportsNotApplicable(t *testing.T) {
+	facts := &ScanFacts{Dependabot: dependabotFactsWithEcosystem("docker")}
+
+	if findings := evaluateUpdateToolActionsCooldownFacts(facts); len(findings) != 0 {
+		t.Fatalf("findings = %+v, want none", findings)
+	}
+	success := updateToolActionsCooldownSuccessFinding(ruleNameUpdateToolActionsCooldown, SeverityLow, facts)
+	if success == nil {
+		t.Fatal("expected a not-applicable success finding; a silent rule reads as a clean pass")
 	}
 }
 

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1,0 +1,150 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The golden matrix drives the scanner API directly, because a failure there
+// points straight at scanner behaviour. That path never exercises the CLI
+// wiring an operator actually goes through, so these tests run the real binary:
+// flag parsing, config resolution, token resolution, output encoding, and the
+// process exit code.
+
+// buildCLI compiles the binary under test once per run. Building rather than
+// reusing ./bin/gasa guarantees the tests exercise the current working tree
+// instead of whatever was last built by hand.
+func buildCLI(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "gasa")
+	cmd := exec.Command("go", "build", "-o", bin, "../..")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build gasa: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// runGasa runs the binary and returns stdout, stderr and the exit code.
+func runGasa(t *testing.T, bin string, args ...string) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+
+	err := cmd.Run()
+	code := 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("run %s: %v\nstderr: %s", bin, err, stderr.String())
+	}
+	return stdout.String(), stderr.String(), code
+}
+
+// TestCLIJSONMatchesGolden proves the binary and the scanner API agree. If the
+// CLI ever drops findings on the way to stdout — a filter, an encoding bug, a
+// config resolved differently — the API-level matrix would not notice.
+func TestCLIJSONMatchesGolden(t *testing.T) {
+	bin := buildCLI(t)
+
+	for _, fx := range fixtureRepos {
+		t.Run(fx.repo, func(t *testing.T) {
+			stdout, stderr, code := runGasa(t, bin,
+				"run", fx.owner+"/"+fx.repo, "--no-config", "--success", "--format", "json")
+			if code != 0 {
+				t.Fatalf("exit code = %d, want 0\nstderr: %s", code, stderr)
+			}
+
+			var result struct {
+				Findings []struct {
+					Rule    string `json:"rule"`
+					ID      string `json:"id"`
+					Success bool   `json:"success"`
+				} `json:"findings"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("stdout is not valid JSON: %v\n%s", err, truncate(stdout))
+			}
+
+			var g golden
+			raw, err := os.ReadFile(filepath.Join(goldenDir, fx.repo+".golden.json"))
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if err := json.Unmarshal(raw, &g); err != nil {
+				t.Fatalf("parse golden: %v", err)
+			}
+
+			if len(result.Findings) != len(g.Findings) {
+				t.Fatalf("CLI reported %d findings, golden has %d", len(result.Findings), len(g.Findings))
+			}
+
+			want := make(map[string]bool, len(g.Findings))
+			for _, e := range g.Findings {
+				want[e.Rule+"\x00"+e.ID] = e.Success
+			}
+			for _, f := range result.Findings {
+				success, ok := want[f.Rule+"\x00"+f.ID]
+				if !ok {
+					t.Errorf("CLI reported a finding absent from the golden: rule=%s id=%s", f.Rule, f.ID)
+					continue
+				}
+				if success != f.Success {
+					t.Errorf("rule=%s id=%s success: CLI=%t golden=%t", f.Rule, f.ID, f.Success, success)
+				}
+			}
+		})
+	}
+}
+
+// TestCLIHumanOutputNamesFailingRules covers the default table path, which is
+// what most operators see and which the JSON tests never touch.
+func TestCLIHumanOutputNamesFailingRules(t *testing.T) {
+	bin := buildCLI(t)
+
+	stdout, stderr, code := runGasa(t, bin, "run", "bretfisher/gasa-fail", "--no-config")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0\nstderr: %s", code, stderr)
+	}
+	for _, want := range []string{"pull_request_target", "Unpinned Action"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("table output missing %q\n%s", want, truncate(stdout))
+		}
+	}
+	// The scan header goes to stderr so stdout stays pipeable.
+	if !strings.Contains(stderr, "Config: disabled (--no-config)") {
+		t.Errorf("stderr should record that config was disabled, got: %s", truncate(stderr))
+	}
+}
+
+// TestCLIRejectsConflictingConfigFlags is a cheap guard on the flag wiring the
+// whole suite depends on: if --no-config stopped working, every scan above
+// would silently pick up the repository's own .gasa.yaml and run a reduced rule
+// set while still passing.
+func TestCLIRejectsConflictingConfigFlags(t *testing.T) {
+	bin := buildCLI(t)
+
+	_, stderr, code := runGasa(t, bin, "run", "bretfisher/gasa-pass", "--no-config", "--config", ".gasa.yaml")
+	if code == 0 {
+		t.Fatal("expected a non-zero exit for mutually exclusive flags")
+	}
+	if !strings.Contains(stderr, "no-config") {
+		t.Errorf("error should name the conflicting flags, got: %s", truncate(stderr))
+	}
+}
+
+func truncate(s string) string {
+	const limit = 2000
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "\n… truncated"
+}

--- a/test/e2e/doc.go
+++ b/test/e2e/doc.go
@@ -1,0 +1,8 @@
+// Package e2e holds the end-to-end suite that scans the real fixture
+// repositories. Every test file carries the `e2e` build tag so the default
+// `go test ./...` stays hermetic and offline.
+//
+// This file deliberately carries no build tag. Without it the package has no
+// Go files when the tag is absent, and golangci-lint fails typechecking outright
+// with "build constraints exclude all Go files" rather than simply skipping it.
+package e2e

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,286 @@
+//go:build e2e
+
+// Package e2e scans real GitHub repositories and asserts what gasa reports.
+//
+// These are integration tests, not unit tests: they cross a network boundary
+// and an auth boundary, and they are the only tests that can catch GitHub
+// changing its own behaviour. The build tag keeps them out of `make test` so
+// the default gate stays hermetic, fast, and offline — a tag rather than
+// t.Skip, so the default suite cannot make a network call even by accident.
+//
+//	make test-e2e
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bretfisher/gasa/internal/scanner"
+)
+
+var update = flag.Bool("update", false, "rewrite the golden files from the current scan results")
+
+const (
+	goldenDir   = "../../testdata/e2e/expected"
+	scanTimeout = 3 * time.Minute
+)
+
+// fixtureRepos are the repositories under test and what each exists to prove.
+// Kept here rather than derived from the fixture manifests so a manifest bug
+// cannot silently shrink the set of repositories the suite scans.
+var fixtureRepos = []struct {
+	owner string
+	repo  string
+	role  string
+}{
+	{"bretfisher", "gasa-pass", "every rule passes"},
+	{"bretfisher", "gasa-fail", "fails every rule it structurally can"},
+	{"bretfisher", "gasa-fail-private", "fails the two update-tool rules that gasa-fail cannot"},
+}
+
+// goldenEntry is what the suite asserts: a rule's outcome, not its prose.
+//
+// Title, Description and Remediation are deliberately excluded. They are
+// rendered from docs/rules/*.md front-matter templates, so asserting them would
+// turn every wording fix into an e2e failure. FixURL and DocURL have dedicated
+// unit tests, and Line couples the golden to fixture file formatting.
+type goldenEntry struct {
+	Rule     string `json:"rule"`
+	ID       string `json:"id"`
+	Severity string `json:"severity"`
+	Success  bool   `json:"success"`
+}
+
+type golden struct {
+	Repo       string        `json:"repo"`
+	Incomplete []string      `json:"incomplete"`
+	Findings   []goldenEntry `json:"findings"`
+}
+
+func newScanner(t *testing.T) *scanner.Scanner {
+	t.Helper()
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		token = os.Getenv("GH_TOKEN")
+	}
+	if token == "" {
+		token = strings.TrimSpace(runCmd(t, "gh", "auth", "token"))
+	}
+	if token == "" {
+		t.Fatal("no GitHub token: set GITHUB_TOKEN, GH_TOKEN, or sign in with `gh auth login`.\n" +
+			"In CI this is E2E_REPO_PAT, which needs Contents: Read and Administration: Read on all three fixture repositories.")
+	}
+	return scanner.NewWithToken(token)
+}
+
+func runCmd(t *testing.T, name string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command(name, args...).Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+// scanFixture scans one repository with no config at all, so the full
+// registered rule set always runs regardless of what config sits in the working
+// directory. A local .gasa.yaml exclusion silently shrinking the rule set is
+// the exact failure this suite exists to catch.
+func scanFixture(t *testing.T, s *scanner.Scanner, owner, repo string) *scanner.ScanResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), scanTimeout)
+	defer cancel()
+
+	result, err := s.ScanRepoWithOptions(ctx, owner, repo, scanner.ScanOptions{
+		IncludeSuccess: true,
+		Config:         nil,
+	})
+	if err != nil {
+		t.Fatalf("scan %s/%s: %v", owner, repo, err)
+	}
+	if result.Error != "" {
+		t.Fatalf("scan %s/%s reported: %s", owner, repo, result.Error)
+	}
+
+	// A scan that reports nothing is never a legitimate result here: with
+	// IncludeSuccess set, every registered rule contributes either a finding or
+	// a success. Asserting it explicitly is what stops an empty result set from
+	// being compared against an empty golden and passing.
+	if want := len(scanner.AvailableRules()); len(result.Findings) < want {
+		t.Fatalf("scan %s/%s returned %d findings for %d registered rules; every rule must report",
+			owner, repo, len(result.Findings), want)
+	}
+	return result
+}
+
+func toGolden(repo string, result *scanner.ScanResult) golden {
+	entries := make([]goldenEntry, 0, len(result.Findings))
+	for _, f := range result.Findings {
+		entries = append(entries, goldenEntry{Rule: f.Rule, ID: f.ID, Severity: f.Severity, Success: f.Success})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Rule != entries[j].Rule {
+			return entries[i].Rule < entries[j].Rule
+		}
+		return entries[i].ID < entries[j].ID
+	})
+
+	incomplete := append([]string(nil), result.Incomplete...)
+	sort.Strings(incomplete)
+	if incomplete == nil {
+		incomplete = []string{}
+	}
+	return golden{Repo: repo, Incomplete: incomplete, Findings: entries}
+}
+
+// TestScanMatchesGolden is the core regression net: a rule that silently stops
+// firing, or starts firing where it should not, changes this file.
+func TestScanMatchesGolden(t *testing.T) {
+	s := newScanner(t)
+
+	for _, fx := range fixtureRepos {
+		t.Run(fx.repo, func(t *testing.T) {
+			got := toGolden(fx.repo, scanFixture(t, s, fx.owner, fx.repo))
+			path := filepath.Join(goldenDir, fx.repo+".golden.json")
+
+			if *update {
+				writeGolden(t, path, got)
+				t.Logf("updated %s", path)
+				return
+			}
+
+			wantRaw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read golden: %v\nrun `make e2e-update` to create it", err)
+			}
+			var want golden
+			if err := json.Unmarshal(wantRaw, &want); err != nil {
+				t.Fatalf("parse golden %s: %v", path, err)
+			}
+
+			diffGolden(t, fx.repo, want, got)
+		})
+	}
+}
+
+func writeGolden(t *testing.T, path string, g golden) {
+	t.Helper()
+	raw, err := json.MarshalIndent(g, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal golden: %v", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("write golden: %v", err)
+	}
+}
+
+// diffGolden reports differences per entry rather than dumping two blobs, so a
+// failure names the rule that changed.
+func diffGolden(t *testing.T, repo string, want, got golden) {
+	t.Helper()
+
+	index := func(g golden) map[string]goldenEntry {
+		m := make(map[string]goldenEntry, len(g.Findings))
+		for _, e := range g.Findings {
+			m[e.Rule+"\x00"+e.ID] = e
+		}
+		return m
+	}
+	wantIdx, gotIdx := index(want), index(got)
+
+	for key, w := range wantIdx {
+		g, ok := gotIdx[key]
+		if !ok {
+			t.Errorf("%s: expected finding no longer reported: rule=%s id=%s (success=%t)", repo, w.Rule, w.ID, w.Success)
+			continue
+		}
+		if g.Success != w.Success {
+			t.Errorf("%s: rule=%s id=%s success changed %t -> %t", repo, w.Rule, w.ID, w.Success, g.Success)
+		}
+		if g.Severity != w.Severity {
+			t.Errorf("%s: rule=%s id=%s severity changed %q -> %q", repo, w.Rule, w.ID, w.Severity, g.Severity)
+		}
+	}
+	for key, g := range gotIdx {
+		if _, ok := wantIdx[key]; !ok {
+			t.Errorf("%s: unexpected new finding: rule=%s id=%s success=%t severity=%s", repo, g.Rule, g.ID, g.Success, g.Severity)
+		}
+	}
+
+	if strings.Join(want.Incomplete, "|") != strings.Join(got.Incomplete, "|") {
+		t.Errorf("%s: incomplete checks changed\n  want: %v\n  got:  %v", repo, want.Incomplete, got.Incomplete)
+	}
+}
+
+// TestEveryRuleHasPassAndFailCoverage is what makes this suite durable. Adding a
+// rule without fixture coverage becomes a test failure instead of an untested
+// rule quietly shipping.
+//
+// The invariant is "a fail case in at least one fail fixture", not "gasa-fail
+// fails everything": update-tool-configuration fires only when no tool covers
+// github-actions while update-tool-actions-cooldown fires only when one does,
+// so those conditions are exact complements and no single repository can fail
+// both.
+func TestEveryRuleHasPassAndFailCoverage(t *testing.T) {
+	passing := make(map[string]bool)
+	failing := make(map[string]bool)
+
+	for _, fx := range fixtureRepos {
+		var g golden
+		raw, err := os.ReadFile(filepath.Join(goldenDir, fx.repo+".golden.json"))
+		if err != nil {
+			t.Fatalf("read golden for %s: %v", fx.repo, err)
+		}
+		if err := json.Unmarshal(raw, &g); err != nil {
+			t.Fatalf("parse golden for %s: %v", fx.repo, err)
+		}
+		for _, e := range g.Findings {
+			if e.Success {
+				passing[e.Rule] = true
+			} else {
+				failing[e.Rule] = true
+			}
+		}
+	}
+
+	for _, r := range scanner.AvailableRules() {
+		if !passing[r.Name] {
+			t.Errorf("rule %q has no passing case in any fixture; gasa-pass should demonstrate it clean", r.Name)
+		}
+		if !failing[r.Name] {
+			t.Errorf("rule %q has no failing case in any fixture; add one to a fail fixture or the rule is untested end to end", r.Name)
+		}
+	}
+}
+
+// TestNoRuleIsSilent guards the failure mode that motivated this whole phase: a
+// rule that produces neither a finding nor a success vanishes from the report,
+// which in every output format is indistinguishable from a clean pass.
+func TestNoRuleIsSilent(t *testing.T) {
+	s := newScanner(t)
+
+	for _, fx := range fixtureRepos {
+		t.Run(fx.repo, func(t *testing.T) {
+			result := scanFixture(t, s, fx.owner, fx.repo)
+
+			reported := make(map[string]bool)
+			for _, f := range result.Findings {
+				reported[f.Rule] = true
+			}
+			for _, r := range scanner.AvailableRules() {
+				if !reported[r.Name] {
+					t.Errorf("rule %q reported nothing at all for %s (%s) — neither a finding nor a success",
+						r.Name, fx.repo, fx.role)
+				}
+			}
+		})
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,30 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bretfisher/gasa/internal/scanner"
+)
+
+// TestMain registers the rule documentation before any test runs.
+//
+// The rule registry is built from docs/rules/*.md front matter, and the binary
+// populates it at startup from an embedded FS. Anything that imports the scanner
+// package directly — this suite included — must do the same, or the registry is
+// empty, no rules resolve, and every scan returns nothing.
+//
+// That failure is silent and dangerous: the first version of this suite passed
+// while comparing an empty result set against an empty golden file. The
+// sanity check below exists so it can never happen again.
+func TestMain(m *testing.M) {
+	if err := scanner.LoadRuleDocs(os.DirFS("../../docs/rules")); err != nil {
+		panic("loading rule docs for e2e tests: " + err.Error())
+	}
+	if len(scanner.AvailableRules()) == 0 {
+		panic("no rules registered after loading docs/rules; the suite would pass vacuously")
+	}
+	os.Exit(m.Run())
+}

--- a/testdata/e2e/expected/gasa-fail-private.golden.json
+++ b/testdata/e2e/expected/gasa-fail-private.golden.json
@@ -1,0 +1,66 @@
+{
+  "repo": "gasa-fail-private",
+  "incomplete": [],
+  "findings": [
+    {
+      "rule": "actions/permissions/allowed-actions-policy",
+      "id": "success-actions-permissions-allowed-actions-policy",
+      "severity": "medium",
+      "success": true
+    },
+    {
+      "rule": "actions/permissions/fork-pr-contributor-approval",
+      "id": "success-actions-permissions-fork-pr-contributor-approval",
+      "severity": "high",
+      "success": true
+    },
+    {
+      "rule": "actions/permissions/workflow/actions-can-approve-prs",
+      "id": "success-actions-permissions-workflow-actions-can-approve-prs",
+      "severity": "medium",
+      "success": true
+    },
+    {
+      "rule": "actions/permissions/workflow/default-workflow-permissions",
+      "id": "success-actions-permissions-workflow-default-workflow-permissions",
+      "severity": "high",
+      "success": true
+    },
+    {
+      "rule": "updates/update-tool-actions-cooldown",
+      "id": "update-tool-actions-missing-cooldown",
+      "severity": "low",
+      "success": false
+    },
+    {
+      "rule": "updates/update-tool-actions-pinning",
+      "id": "update-tool-actions-not-pinning",
+      "severity": "medium",
+      "success": false
+    },
+    {
+      "rule": "updates/update-tool-configuration",
+      "id": "success-updates-update-tool-configuration",
+      "severity": "medium",
+      "success": true
+    },
+    {
+      "rule": "workflows/action-version-pinning",
+      "id": "success-workflows-action-version-pinning",
+      "severity": "high",
+      "success": true
+    },
+    {
+      "rule": "workflows/pull-request-target",
+      "id": "success-workflows-pull-request-target",
+      "severity": "critical",
+      "success": true
+    },
+    {
+      "rule": "workflows/workflow-permissions",
+      "id": "success-workflows-workflow-permissions",
+      "severity": "high",
+      "success": true
+    }
+  ]
+}

--- a/testdata/e2e/expected/gasa-fail.golden.json
+++ b/testdata/e2e/expected/gasa-fail.golden.json
@@ -1,0 +1,102 @@
+{
+  "repo": "gasa-fail",
+  "incomplete": [],
+  "findings": [
+    {
+      "rule": "actions/permissions/allowed-actions-policy",
+      "id": "settings-all-actions-allowed",
+      "severity": "medium",
+      "success": false
+    },
+    {
+      "rule": "actions/permissions/fork-pr-contributor-approval",
+      "id": "settings-fork-pr-contributor-approval-too-permissive",
+      "severity": "high",
+      "success": false
+    },
+    {
+      "rule": "actions/permissions/workflow/actions-can-approve-prs",
+      "id": "settings-actions-can-approve-prs",
+      "severity": "medium",
+      "success": false
+    },
+    {
+      "rule": "actions/permissions/workflow/default-workflow-permissions",
+      "id": "settings-default-permissions-write",
+      "severity": "high",
+      "success": false
+    },
+    {
+      "rule": "updates/update-tool-actions-cooldown",
+      "id": "success-updates-update-tool-actions-cooldown",
+      "severity": "low",
+      "success": true
+    },
+    {
+      "rule": "updates/update-tool-actions-pinning",
+      "id": "success-updates-update-tool-actions-pinning",
+      "severity": "medium",
+      "success": true
+    },
+    {
+      "rule": "updates/update-tool-configuration",
+      "id": "update-tool-missing-actions",
+      "severity": "medium",
+      "success": false
+    },
+    {
+      "rule": "workflows/action-version-pinning",
+      "id": "unpinned-.github/workflows/bad-no-sha-pins.yaml-actions-checkout-v4",
+      "severity": "high",
+      "success": false
+    },
+    {
+      "rule": "workflows/action-version-pinning",
+      "id": "unpinned-.github/workflows/bad-no-sha-pins.yaml-actions-setup-node-v4",
+      "severity": "high",
+      "success": false
+    },
+    {
+      "rule": "workflows/action-version-pinning",
+      "id": "unpinned-.github/workflows/bad-no-sha-pins.yaml-actions-upload-artifact-v4",
+      "severity": "high",
+      "success": false
+    },
+    {
+      "rule": "workflows/action-version-pinning",
+      "id": "unpinned-.github/workflows/bad-no-sha-pins.yaml-codecov-codecov-action-v4",
+      "severity": "high",
+      "success": false
+    },
+    {
+      "rule": "workflows/action-version-pinning",
+      "id": "unpinned-.github/workflows/bad-pull-request-target.yaml-actions-checkout-v7",
+      "severity": "high",
+      "success": false
+    },
+    {
+      "rule": "workflows/action-version-pinning",
+      "id": "unpinned-.github/workflows/bad-pull-request-target.yaml-actions-github-script-v7",
+      "severity": "high",
+      "success": false
+    },
+    {
+      "rule": "workflows/pull-request-target",
+      "id": "dangerous-trigger-.github/workflows/bad-pull-request-target.yaml",
+      "severity": "critical",
+      "success": false
+    },
+    {
+      "rule": "workflows/workflow-permissions",
+      "id": "no-permissions-.github/workflows/bad-no-sha-pins.yaml",
+      "severity": "high",
+      "success": false
+    },
+    {
+      "rule": "workflows/workflow-permissions",
+      "id": "no-permissions-.github/workflows/bad-pull-request-target.yaml",
+      "severity": "high",
+      "success": false
+    }
+  ]
+}

--- a/testdata/e2e/expected/gasa-pass.golden.json
+++ b/testdata/e2e/expected/gasa-pass.golden.json
@@ -1,0 +1,66 @@
+{
+  "repo": "gasa-pass",
+  "incomplete": [],
+  "findings": [
+    {
+      "rule": "actions/permissions/allowed-actions-policy",
+      "id": "success-actions-permissions-allowed-actions-policy",
+      "severity": "medium",
+      "success": true
+    },
+    {
+      "rule": "actions/permissions/fork-pr-contributor-approval",
+      "id": "success-actions-permissions-fork-pr-contributor-approval",
+      "severity": "high",
+      "success": true
+    },
+    {
+      "rule": "actions/permissions/workflow/actions-can-approve-prs",
+      "id": "success-actions-permissions-workflow-actions-can-approve-prs",
+      "severity": "medium",
+      "success": true
+    },
+    {
+      "rule": "actions/permissions/workflow/default-workflow-permissions",
+      "id": "success-actions-permissions-workflow-default-workflow-permissions",
+      "severity": "high",
+      "success": true
+    },
+    {
+      "rule": "updates/update-tool-actions-cooldown",
+      "id": "success-updates-update-tool-actions-cooldown",
+      "severity": "low",
+      "success": true
+    },
+    {
+      "rule": "updates/update-tool-actions-pinning",
+      "id": "success-updates-update-tool-actions-pinning",
+      "severity": "medium",
+      "success": true
+    },
+    {
+      "rule": "updates/update-tool-configuration",
+      "id": "success-updates-update-tool-configuration",
+      "severity": "medium",
+      "success": true
+    },
+    {
+      "rule": "workflows/action-version-pinning",
+      "id": "success-workflows-action-version-pinning",
+      "severity": "high",
+      "success": true
+    },
+    {
+      "rule": "workflows/pull-request-target",
+      "id": "success-workflows-pull-request-target",
+      "severity": "critical",
+      "success": true
+    },
+    {
+      "rule": "workflows/workflow-permissions",
+      "id": "success-workflows-workflow-permissions",
+      "severity": "high",
+      "success": true
+    }
+  ]
+}


### PR DESCRIPTION
Completes the cross-repository harness on top of the fixture tooling in #51.

> **Why reopened:** the stacked merge mis-targeted — #53 merged into its base branch instead of `main`, and #52 closed unmerged, so only the tooling landed. Content here is byte-identical to the reviewed branches.

## The suite

Scans all three fixture repositories behind an `e2e` build tag, so `make test` cannot reach the network even by accident.

| Test | Layer |
|---|---|
| `TestScanMatchesGolden` | scanner API vs checked-in goldens |
| `TestEveryRuleHasPassAndFailCoverage` | every rule passes somewhere, fails somewhere |
| `TestNoRuleIsSilent` | no rule reports nothing at all |
| `TestCLIJSONMatchesGolden` | the real binary agrees with the API |
| `TestCLIHumanOutputNamesFailingRules` | default table path |
| `TestCLIRejectsConflictingConfigFlags` | the `--no-config` wiring the suite depends on |

## The workflow

Pushes to `main` (path-filtered), a **daily schedule**, manual dispatch — **never `pull_request`**. The job holds a cross-repository PAT and a PR in a Go repo runs attacker-controlled code; `go test` executes whatever the branch added. PAT is an environment secret exposed per-step. `fixtures-verify` runs before the assertions so drift reads as drift.

actionlint, zizmor, and poutine all clean.

## Three defects fixed along the way

**Cooldown and pinning rules went silent** when no update tool covered `github-actions` — the check vanished from the report, indistinguishable from a clean pass, and true of `gasa-fail` for *both* rules. Now reported not-applicable explicitly. All three fixtures report all ten rules.

**The first version of this suite passed against empty data.** The rule registry is populated by the binary at startup, so a package importing the scanner directly registers *no rules* and every scan returned nothing. `TestMain` now refuses to run on an empty registry.

**Super-linter never applied `.golangci.yaml`** — it expects `.golangci.yml`. CI had been linting Go with defaults this whole time. Renaming is what makes the `build-tags` setting for `test/e2e` take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN