### PR TITLE
Add a Renovate config to the gasa-pass fixture

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1302,7 +1302,13 @@ Phase C cannot begin until this stack is merged: PRs #34 and #39 change rule out
    Actions settings. Verified live: 10 of 10 rules report, and exactly rules 9 and 10 fail. Two code
    defects were found in the process — see P1 and P2 below. **Still outstanding: re-scope
    `E2E_REPO_PAT` to include this repository** (see below)
-10. Optional: good Renovate config on `gasa-pass`, which doubles as the live regression test for R20
+10. ~~Optional: good Renovate config on `gasa-pass`~~ **Done 2026-08-12.** `renovate.json` extending
+    `config:best-practices` added to the fixture. This exercises the Renovate fetch/parse path and
+    rule 8's both-tools branch end to end. One honest caveat discovered while landing it: it is
+    **not** a live R20 regression test for the must-pass direction, because `actionsPinningState`
+    short-circuits on gasa-pass's Dependabot `github-actions` entry before preset resolution runs.
+    The preset table's must-NOT-pass direction (`config:recommended`) is what `gasa-fail-private`
+    covers live; the must-pass direction rests on unit tests
 11. Hygiene: make fixture workflow `run:` steps inert (`gasa-fail` only; the new fixture already is)
 
 Decided 2026-08-11: **Dependabot is not suppressed on the fixture repositories.** Churn is accepted and `fixtures-apply` reverts it, which needs no extra setup and self-heals. This closes R2 and R14.

--- a/testdata/e2e/fixtures/gasa-pass/files/renovate.json
+++ b/testdata/e2e/fixtures/gasa-pass/files/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"]
+}


### PR DESCRIPTION
**Stack #61, layer 1 of 9.** Review each layer alone; merge with `gh stack merge 64 --yes --squash` once all nine are approved (a plain `gh pr merge` mis-targets stacked PRs — that's how #52/#53 went wrong).

`gasa-pass` was Dependabot-only, so every Renovate code path — config probing, JSON parsing, the both-tools-valid path, rule 8's "Dependabot and Renovate" success branch — ran end to end against nothing. A `renovate.json` extending `config:best-practices` exercises all of it against a real repository.

**No golden changes**: every rule already passed on gasa-pass and still does.

**Honest caveat vs the plan's original claim:** this is *not* a live R20 regression test for the must-pass direction — `actionsPinningState` short-circuits on the Dependabot `github-actions` entry before preset resolution runs. The must-NOT-pass direction (`config:recommended` ≠ pinning) is what `gasa-fail-private` covers live; must-pass stays on unit tests. PLAN.md records this.

The Renovate app is not installed on gasa-pass, so the config is inert — no update PRs will appear. **Already applied live** (`make fixtures-apply` ran from the top of the stack); until the stack merges, main's nightly `fixtures-verify` reports this file as drift — that is the drift detector working as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN
