### PR TITLE
Make the gasa-fail fixture workflow bodies inert

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1309,7 +1309,11 @@ Phase C cannot begin until this stack is merged: PRs #34 and #39 change rule out
     short-circuits on gasa-pass's Dependabot `github-actions` entry before preset resolution runs.
     The preset table's must-NOT-pass direction (`config:recommended`) is what `gasa-fail-private`
     covers live; the must-pass direction rests on unit tests
-11. Hygiene: make fixture workflow `run:` steps inert (`gasa-fail` only; the new fixture already is)
+11. ~~Hygiene: make fixture workflow `run:` steps inert~~ **Done 2026-08-12.** Both `gasa-fail`
+    workflows now only echo, and the github-script step logs instead of posting a PR comment — which
+    it genuinely would have done, since the repository's default token permission is deliberately
+    `write`. Every rule-relevant byte (triggers, `uses:` refs, absence of `permissions:`) is
+    unchanged, so finding IDs and goldens are untouched
 
 Decided 2026-08-11: **Dependabot is not suppressed on the fixture repositories.** Churn is accepted and `fixtures-apply` reverts it, which needs no extra setup and self-heals. This closes R2 and R14.
 

--- a/testdata/e2e/fixtures/gasa-fail/files/.github/workflows/bad-no-sha-pins.yaml
+++ b/testdata/e2e/fixtures/gasa-fail/files/.github/workflows/bad-no-sha-pins.yaml
@@ -2,6 +2,10 @@
 # Every `uses:` below is pinned to a mutable tag (@v4, @v5...) on purpose.
 # Run `zizmor .` to see the unpinned-uses findings, then `zizmor --fix .`
 # (with a GITHUB_TOKEN set) to rewrite each tag to its commit SHA.
+#
+# Step bodies are deliberately inert: this file demonstrates the dangerous
+# SHAPE for the gasa test suite, so a trigger firing costs nothing and does
+# nothing. Do not add real commands here.
 name: CI
 
 on:
@@ -24,7 +28,7 @@ jobs:
           node-version: 20
 
       - name: Install & test
-        run: npm ci && npm test
+        run: echo "inert fixture step — no commands are executed in this repository"
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
@@ -33,4 +37,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build
-          path: dist/
+          path: README.md

--- a/testdata/e2e/fixtures/gasa-fail/files/.github/workflows/bad-pull-request-target.yaml
+++ b/testdata/e2e/fixtures/gasa-fail/files/.github/workflows/bad-pull-request-target.yaml
@@ -2,6 +2,11 @@
 # The example is mostly safe because I've locked down PRs to only ppl with write access and
 #   set Actions to require manual approval for all external contributions
 # GitHub as also hardened things like pull_request_target and actions/checkout in 2026
+#
+# Step bodies are deliberately inert: this file demonstrates the dangerous
+# SHAPE (pull_request_target + untrusted checkout + secrets in scope) for the
+# gasa test suite. A trigger firing costs nothing and does nothing. Do not add
+# real commands here.
 
 name: PR Build & Comment
 
@@ -20,9 +25,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      # ⚠️ ...then executes it, while secrets are in scope
+      # ⚠️ ...where a real workflow would then execute it while secrets are in
+      # scope. This fixture only echoes.
       - name: Install & build
-        run: npm ci && npm run build
+        run: echo "inert fixture step — no commands are executed in this repository"
 
       - name: Comment result
         uses: actions/github-script@v7
@@ -30,9 +36,7 @@ jobs:
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.payload.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Build complete ✅'
-            })
+            // Inert on purpose: the repository default token permission is
+            // deliberately `write` (a gasa fixture state), so a real API call
+            // here would actually succeed. Log and do nothing.
+            console.log("inert fixture — no operations performed")


### PR DESCRIPTION
**Stack #61, layer 2 of 9.**

The two bad-example workflows ran real commands when triggered: npm installs executing repository content, and a github-script step that **posted PR comments** — which stopped being hypothetical when the fixture's default token permission was deliberately flipped to `write`. A run of the `pull_request_target` workflow held a write token and genuinely used it.

Step bodies now echo/log and do nothing. **Every rule-relevant byte is unchanged** — triggers, every unpinned `uses:` ref, the absence of `permissions:` — so all finding IDs and goldens stay identical. The files keep their warning comments (they demonstrate the dangerous *shape*) plus a header saying the bodies are inert on purpose, so nobody "fixes" them into doing real work again.

Bonus: `upload-artifact`'s path moves from `dist/` (never existed → every run red) to `README.md`, so the fixture repo's CI stops being permanently red for an unrelated reason.

Already applied live via `make fixtures-apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN
