### PR TITLE
Resolve update-tool configs from directory listings instead of path probes (R17)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1204,7 +1204,7 @@ Correction to R18 as originally written: adding Renovate to `gasa-pass` does **n
   concludes the rule evaluated and passed; the report shows the rule never happened. Whatever fix
   lands for R10's silent-emission problem should also make the debug line distinguish "passed and said
   so" from "produced nothing"
-- **R17 — efficiency, rule 8 and batch mode: nine 404 probes per scan just to look for Renovate.** A
+- ~~**R17**~~ **Done 2026-08-12** — efficiency, rule 8 and batch mode: nine 404 probes per scan just to look for Renovate. A
   full scan of `gasa-pass` issues 19 GitHub API calls, and **9 of them** are contents requests for
   Renovate config paths that do not exist (`renovate.json`, `renovate.json5`,
   `.github/renovate.json*`, `.gitlab/renovate.json*`, `.renovaterc*`). The scanner short-circuits at
@@ -1370,7 +1370,11 @@ Two further defects were found while building it, both fixed in the same pull re
   nothing. `TestMain` now refuses to run on an empty registry, and a scan reporting fewer findings
   than there are registered rules is a hard failure
 
-**Phase E — deferred.** R17 (nine Renovate 404 probes per scan) is an efficiency item that blocks nothing. The three new-rule candidates surfaced by this audit (R6, R8, R16) have moved to Phase 13.
+**Phase E.** ~~R17 (nine Renovate 404 probes per scan)~~ **Done 2026-08-12** — a file-inventory
+collector lists the root and dot-directories (one or two requests) and the update-tool collectors
+skip paths the listings proved absent, dropping the common no-Renovate case from eleven requests to
+two or three. Any listing failure or truncation falls back to per-path probing, so it can only cost
+speed, never correctness. The three new-rule candidates (R6, R8, R16) moved to Phase 13.
 
 ### Open decisions
 

--- a/docs/rules/update-tool-configuration.md
+++ b/docs/rules/update-tool-configuration.md
@@ -84,10 +84,17 @@ renovate.json5
 
 API calls made:
 
-- `GET /repos/{owner}/{repo}/contents/.github/dependabot.yml`
-- fallback: `GET /repos/{owner}/{repo}/contents/.github/dependabot.yaml`
-- `GET /repos/{owner}/{repo}/contents/<each renovate path>` — stops at first found
+- `GET /repos/{owner}/{repo}/contents/` — root directory listing
+- `GET /repos/{owner}/{repo}/contents/.github` (and `.gitlab`, only when the root listing shows it
+  exists) — directory listings
+- `GET /repos/{owner}/{repo}/contents/<path>` — one fetch per config file the listings proved to
+  exist, in Renovate's own precedence order
 - `GET /repos/{owner}/{repo}/contents/.github/workflows`
+
+The listings replace what used to be one probe per candidate path — eleven requests to establish
+that no update tool exists. If a listing fails or returns at the contents API's 1,000-entry
+truncation cap, the scanner falls back to per-path probing, so a listing problem can only cost
+speed, never correctness.
 
 Decision logic:
 

--- a/docs/rules/update-tool-configuration.md
+++ b/docs/rules/update-tool-configuration.md
@@ -92,8 +92,8 @@ API calls made:
 - `GET /repos/{owner}/{repo}/contents/.github/workflows`
 
 The listings replace what used to be one probe per candidate path — eleven requests to establish
-that no update tool exists. If a listing fails or returns at the contents API's 1,000-entry
-truncation cap, the scanner falls back to per-path probing, so a listing problem can only cost
+that no update tool exists. If a listing fails or returns at the 1,000-entry truncation cap
+of the contents API, the scanner falls back to per-path probing, so a listing problem can only cost
 speed, never correctness.
 
 Decision logic:

--- a/internal/scanner/facts.go
+++ b/internal/scanner/facts.go
@@ -154,11 +154,23 @@ func (c *factCollector) collectFacts(ctx context.Context, owner, repo string, re
 		dependabot DependabotFacts
 		renovate   RenovateFacts
 	)
-	wg.Add(4)
+
+	// The file inventory (one or two directory listings) is what lets the
+	// Dependabot and Renovate collectors skip absent config paths without a
+	// request each. It runs concurrently with the workflow and settings
+	// collectors, which do not consume it; only the two update-tool collectors
+	// wait for it before starting.
+	invCh := make(chan fileInventory, 1)
+	go func() { invCh <- c.collectFileInventory(ctx, owner, repo, dbg) }()
+
+	wg.Add(2)
 	go func() { defer wg.Done(); workflows = c.collectWorkflowFacts(ctx, owner, repo, dbg) }()
 	go func() { defer wg.Done(); settings = c.collectActionsSettingsFacts(ctx, owner, repo, dbg) }()
-	go func() { defer wg.Done(); dependabot = c.collectDependabotFacts(ctx, owner, repo, false, dbg) }()
-	go func() { defer wg.Done(); renovate = c.collectRenovateFacts(ctx, owner, repo, false, dbg) }()
+
+	inv := <-invCh
+	wg.Add(2)
+	go func() { defer wg.Done(); dependabot = c.collectDependabotFacts(ctx, owner, repo, false, inv, dbg) }()
+	go func() { defer wg.Done(); renovate = c.collectRenovateFacts(ctx, owner, repo, false, inv, dbg) }()
 	wg.Wait()
 
 	hasWorkflows := len(workflows) > 0

--- a/internal/scanner/inventory.go
+++ b/internal/scanner/inventory.go
@@ -1,0 +1,134 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v84/github"
+)
+
+// fileInventory records which files exist at the repository root and inside the
+// .github/ and .gitlab/ directories — the only three places the Dependabot and
+// Renovate collectors ever look.
+//
+// Why it exists: the collectors used to probe every candidate config path with
+// its own GET, and a repository *without* Renovate — the common case — paid all
+// nine 404s on every scan. With Dependabot's two probes that was 11 requests to
+// establish absence. Listing the three directories answers the same question in
+// at most three requests (usually one or two, since .gitlab/ is only listed
+// when the root shows it exists), which matters for batch scans: at ~19 calls
+// per repo, an authenticated 5,000/hour budget capped batch runs near 260
+// repos/hour, with nearly half the budget spent proving files absent.
+type fileInventory struct {
+	// Complete reports whether the listings fully answered "which files exist".
+	// When false the collectors fall back to per-path probing, so a listing
+	// failure can only cost speed, never correctness.
+	Complete bool
+
+	paths map[string]bool
+}
+
+// Has reports whether the listing saw the given path. Only meaningful when
+// Complete is true.
+func (inv fileInventory) Has(path string) bool {
+	return inv.paths[path]
+}
+
+// probeEverything is the zero-value inventory: incomplete, so every consumer
+// probes each path individually. It is the explicit fallback for listing
+// failures and the fixture for tests that exercise the probing code path.
+func probeEverything() fileInventory {
+	return fileInventory{}
+}
+
+// inventoryDirs are the directories the update-tool collectors care about. The
+// root is always listed; the dot-directories only when the root listing shows
+// them, which keeps the common case at two requests and a bare repository at
+// one.
+var inventoryDirs = []string{".github", ".gitlab"}
+
+// Entry types in a contents-API directory listing.
+const (
+	entryTypeFile = "file"
+	entryTypeDir  = "dir"
+)
+
+// contentsListingCap is the GitHub contents API's per-directory limit. A
+// directory with more entries is silently truncated, so a listing that returns
+// exactly this many entries cannot prove absence and the inventory falls back
+// to probing.
+const contentsListingCap = 1000
+
+// collectFileInventory lists the repository root and any relevant
+// dot-directories. Every failure mode degrades to probeEverything rather than
+// guessing: a wrong "absent" here would make the update-tool rules report a
+// missing config that exists, which is a false finding invented from a
+// transport problem.
+func (c *factCollector) collectFileInventory(ctx context.Context, owner, repo string, dbg DebugLogger) fileInventory {
+	repoFull := owner + "/" + repo
+	inv := fileInventory{paths: make(map[string]bool)}
+
+	rootEntries, ok := c.listDirectory(ctx, owner, repo, "", repoFull, dbg)
+	if !ok {
+		return probeEverything()
+	}
+
+	dirs := make(map[string]bool)
+	for _, entry := range rootEntries {
+		switch entry.GetType() {
+		case entryTypeFile:
+			inv.paths[entry.GetName()] = true
+		case entryTypeDir:
+			dirs[entry.GetName()] = true
+		}
+	}
+
+	for _, dir := range inventoryDirs {
+		if !dirs[dir] {
+			continue
+		}
+		entries, ok := c.listDirectory(ctx, owner, repo, dir, repoFull, dbg)
+		if !ok {
+			return probeEverything()
+		}
+		for _, entry := range entries {
+			if entry.GetType() == entryTypeFile {
+				inv.paths[dir+"/"+entry.GetName()] = true
+			}
+		}
+	}
+
+	inv.Complete = true
+	if dbg != nil {
+		dbg(repoFull, fmt.Sprintf("file inventory complete: %d files across root and dot-directories", len(inv.paths)))
+	}
+	return inv
+}
+
+// listDirectory returns a directory's entries and whether the answer is
+// trustworthy. A 404 is a trustworthy "directory does not exist" (including the
+// empty-repository case for the root); an error or a listing at the API's
+// truncation cap is not.
+func (c *factCollector) listDirectory(ctx context.Context, owner, repo, dir, repoFull string, dbg DebugLogger) ([]*github.RepositoryContent, bool) {
+	if dbg != nil {
+		dbg(repoFull, "GET /repos/"+repoFull+"/contents/"+dir+" (listing)")
+	}
+	_, entries, _, err := c.client.Repositories.GetContents(ctx, owner, repo, dir, nil)
+	switch {
+	case isNotFound(err):
+		return nil, true
+	case err != nil:
+		if dbg != nil {
+			dbg(repoFull, "listing "+dir+" failed ("+describeFetchError(err)+") — falling back to per-path probing")
+		}
+		return nil, false
+	case len(entries) >= contentsListingCap:
+		// Cannot distinguish "exactly at the cap" from "truncated", so treat the
+		// whole inventory as unusable rather than risk a false "absent".
+		if dbg != nil {
+			dbg(repoFull, fmt.Sprintf("listing %s returned %d entries (API cap) — falling back to per-path probing", dir, len(entries)))
+		}
+		return nil, false
+	}
+	return entries, true
+}

--- a/internal/scanner/inventory_test.go
+++ b/internal/scanner/inventory_test.go
@@ -1,0 +1,174 @@
+package scanner
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/go-github/v84/github"
+)
+
+// countingMux records every request path so tests can assert not just what the
+// scanner concluded but how many requests it spent getting there — the entire
+// point of the file inventory.
+type countingMux struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+func (c *countingMux) record(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.paths = append(c.paths, path)
+}
+
+func (c *countingMux) contentsRequests() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []string
+	for _, p := range c.paths {
+		if strings.Contains(p, "/contents/") {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func newCountingScanner(t *testing.T) (*Scanner, *http.ServeMux, *countingMux) {
+	t.Helper()
+	s, mux := newTestScanner(t, true)
+	counter := &countingMux{}
+	// Wrap by re-registering: net/http has no middleware hook on ServeMux, so
+	// tests register through recordJSON/record404 below instead.
+	return s, mux, counter
+}
+
+func recordJSON(mux *http.ServeMux, counter *countingMux, path string, v any) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		counter.record(r.URL.Path)
+		handleJSONResponse(w, v)
+	})
+}
+
+// TestInventorySkipsAbsentConfigProbes is the R17 regression test: a repository
+// with Dependabot only must resolve both update tools from the directory
+// listings plus one config fetch — never the nine Renovate 404 probes and the
+// second Dependabot probe it used to pay.
+func TestInventorySkipsAbsentConfigProbes(t *testing.T) {
+	s, mux, counter := newCountingScanner(t)
+
+	recordJSON(mux, counter, "/repos/owner/repo", map[string]any{"full_name": "owner/repo", "default_branch": "main"})
+	recordJSON(mux, counter, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "selected"})
+	recordJSON(mux, counter, "/repos/owner/repo/actions/permissions/workflow", map[string]any{"default_workflow_permissions": "read", "can_approve_pull_request_reviews": false})
+	recordJSON(mux, counter, "/repos/owner/repo/actions/permissions/fork-pr-contributor-approval", map[string]any{"approval_policy": "all_external_contributors"})
+
+	depConfig := "version: 2\nupdates:\n  - package-ecosystem: github-actions\n    directory: /\n    schedule:\n      interval: weekly\n    cooldown:\n      default-days: 7\n"
+	rootListing := []*github.RepositoryContent{dirEntry(".github"), fileEntry("README.md")}
+	githubListing := []*github.RepositoryContent{fileEntry("dependabot.yml"), dirEntry("workflows")}
+	mux.HandleFunc("/repos/owner/repo/contents/", func(w http.ResponseWriter, r *http.Request) {
+		counter.record(r.URL.Path)
+		switch r.URL.Path {
+		case "/repos/owner/repo/contents/":
+			handleJSONResponse(w, rootListing)
+		case "/repos/owner/repo/contents/.github":
+			handleJSONResponse(w, githubListing)
+		case "/repos/owner/repo/contents/.github/dependabot.yml":
+			handleJSONResponse(w, encodedContent(".github/dependabot.yml", depConfig))
+		case "/repos/owner/repo/contents/.github/workflows":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("unexpected contents request: %s — the inventory should have proven this path absent", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	result, err := s.ScanRepo(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Error != "" {
+		t.Fatalf("unexpected result.Error: %s", result.Error)
+	}
+	if len(result.Incomplete) != 0 {
+		t.Fatalf("scan reported incomplete: %v", result.Incomplete)
+	}
+
+	// Root listing + .github listing + workflows listing + one dependabot
+	// fetch. Anything more means probes the inventory should have prevented.
+	if got := counter.contentsRequests(); len(got) != 4 {
+		t.Fatalf("contents requests = %d, want 4:\n%s", len(got), strings.Join(got, "\n"))
+	}
+}
+
+// A repository with no files at all is one listing: the root 404 is a
+// determinate "empty repository", not a failure to look.
+func TestInventoryEmptyRepositoryIsOneListing(t *testing.T) {
+	s, mux, counter := newCountingScanner(t)
+
+	recordJSON(mux, counter, "/repos/owner/repo", map[string]any{"full_name": "owner/repo", "default_branch": "main"})
+	recordJSON(mux, counter, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "selected"})
+	recordJSON(mux, counter, "/repos/owner/repo/actions/permissions/workflow", map[string]any{"default_workflow_permissions": "read", "can_approve_pull_request_reviews": false})
+	recordJSON(mux, counter, "/repos/owner/repo/actions/permissions/fork-pr-contributor-approval", map[string]any{"approval_policy": "all_external_contributors"})
+	mux.HandleFunc("/repos/owner/repo/contents/", func(w http.ResponseWriter, r *http.Request) {
+		counter.record(r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	result, err := s.ScanRepo(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Incomplete) != 0 {
+		t.Fatalf("an empty repository is determinate, not incomplete: %v", result.Incomplete)
+	}
+
+	// Root listing + the workflows-directory listing (the workflow collector
+	// does not consume the inventory). No update-tool probes at all.
+	if got := counter.contentsRequests(); len(got) != 2 {
+		t.Fatalf("contents requests = %d, want 2:\n%s", len(got), strings.Join(got, "\n"))
+	}
+}
+
+// A listing at the contents API's 1000-entry cap cannot prove absence, so the
+// inventory must refuse to vouch and the collectors must fall back to probing.
+func TestInventoryTruncatedListingFallsBackToProbing(t *testing.T) {
+	s, mux := newTestScanner(t, true)
+
+	huge := make([]*github.RepositoryContent, contentsListingCap)
+	for i := range huge {
+		huge[i] = fileEntry("file-" + strings.Repeat("x", i%5) + ".txt")
+	}
+	handleContentsListing(mux, "", huge)
+
+	collector := newTestFactCollector(s)
+	inv := collector.collectFileInventory(context.Background(), "owner", "repo", nil)
+	if inv.Complete {
+		t.Fatal("a listing at the API cap may be truncated and must not be treated as complete")
+	}
+}
+
+// A complete inventory that saw the config must still fetch and parse it.
+func TestInventoryFindsRenovateAtLaterPath(t *testing.T) {
+	s, mux := newTestScanner(t, true)
+
+	handleContentsListing(mux, "", []*github.RepositoryContent{dirEntry(".github")})
+	handleContentsListing(mux, ".github", []*github.RepositoryContent{fileEntry("renovate.json")})
+	handleJSON(mux, "/repos/owner/repo/contents/.github/renovate.json",
+		encodedContent(".github/renovate.json", `{"extends": ["config:recommended"]}`))
+
+	collector := newTestFactCollector(s)
+	inv := collector.collectFileInventory(context.Background(), "owner", "repo", nil)
+	if !inv.Complete {
+		t.Fatal("expected a complete inventory")
+	}
+
+	facts := collector.collectRenovateFacts(context.Background(), "owner", "repo", true, inv, nil)
+	if facts.Missing || facts.Config == nil {
+		t.Fatalf("renovate config should be found via the listing, got %+v", facts)
+	}
+	if facts.Path != ".github/renovate.json" {
+		t.Fatalf("path = %q, want .github/renovate.json", facts.Path)
+	}
+}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -439,6 +439,8 @@ func TestScanRepo_EndToEndMixedFindings(t *testing.T) {
 	scanner, mux := newTestScanner(t, true)
 
 	handleJSON(mux, "/repos/owner/repo", map[string]any{"full_name": "owner/repo", "default_branch": "main"})
+	handleContentsListing(mux, "", []*github.RepositoryContent{dirEntry(".github"), fileEntry("go.mod")})
+	handleContentsListing(mux, ".github", []*github.RepositoryContent{fileEntry("dependabot.yml"), dirEntry("workflows")})
 	handleJSON(mux, "/repos/owner/repo/contents/.github/workflows", []*github.RepositoryContent{{
 		Name: github.Ptr("ci.yml"),
 		Path: github.Ptr(".github/workflows/ci.yml"),
@@ -511,6 +513,12 @@ func TestScanRepoWithOptions_IncompleteOnIndeterminateErrors(t *testing.T) {
 	handleJSON(mux, "/repos/owner/repo", map[string]any{"full_name": "owner/repo", "default_branch": "main"})
 	handle404(mux, "/repos/owner/repo/contents/.github/workflows")
 	handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "selected"})
+	// The directory listings fail too (the trailing-slash pattern catches the
+	// root listing), so the inventory reports itself incomplete and the
+	// collectors fall back to per-path probing — which then hits the 500s
+	// below. Without this the inventory would read the default 404 as an empty
+	// repository and skip the probes entirely.
+	handle500(mux, "/repos/owner/repo/contents/")
 	// Both update-tool config lookups fail indeterminately (server error), so
 	// the scanner cannot tell whether a tool is configured.
 	handle500(mux,
@@ -550,6 +558,8 @@ func TestScanRepoWithOptions_IncludeSuccess(t *testing.T) {
 	scanner, mux := newTestScanner(t, true)
 
 	handleJSON(mux, "/repos/owner/repo", map[string]any{"full_name": "owner/repo", "default_branch": "main"})
+	handleContentsListing(mux, "", []*github.RepositoryContent{dirEntry(".github"), fileEntry("go.mod")})
+	handleContentsListing(mux, ".github", []*github.RepositoryContent{fileEntry("dependabot.yml"), dirEntry("workflows")})
 	handleJSON(mux, "/repos/owner/repo/contents/.github/workflows", []*github.RepositoryContent{{
 		Name: github.Ptr("ci.yml"),
 		Path: github.Ptr(".github/workflows/ci.yml"),

--- a/internal/scanner/testhelpers_test.go
+++ b/internal/scanner/testhelpers_test.go
@@ -101,3 +101,37 @@ func requireContainsLine(t *testing.T, lines []string, want string) {
 
 	t.Fatalf("did not find %q in lines: %+v", want, lines)
 }
+
+// handleContentsListing mocks a directory listing at the given repo-relative
+// directory ("" for the root). The root listing URL carries a trailing slash,
+// which net/http treats as a subtree pattern, so the handler answers only the
+// exact listing URL and returns 404 for anything below it — unregistered file
+// fetches keep behaving exactly as they would on an empty mux.
+func handleContentsListing(mux *http.ServeMux, dir string, entries []*github.RepositoryContent) {
+	base := "/repos/owner/repo/contents/" + dir
+	mux.HandleFunc(base, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != base {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(entries); err != nil {
+			panic(err)
+		}
+	})
+}
+
+func fileEntry(name string) *github.RepositoryContent {
+	return &github.RepositoryContent{Type: github.Ptr("file"), Name: github.Ptr(name)}
+}
+
+func dirEntry(name string) *github.RepositoryContent {
+	return &github.RepositoryContent{Type: github.Ptr("dir"), Name: github.Ptr(name)}
+}
+
+// handleJSONResponse writes v as the response body — the encoding half of
+// handleJSON, for handlers that need their own routing or recording logic.
+func handleJSONResponse(w http.ResponseWriter, v any) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		panic(fmt.Sprintf("failed to encode test JSON: %v", err))
+	}
+}

--- a/internal/scanner/updates.go
+++ b/internal/scanner/updates.go
@@ -93,7 +93,7 @@ func parseRenovateConfig(content string) (*RenovateConfig, error) {
 // Fact collectors
 // ---------------------------------------------------------------------------
 
-func (c *factCollector) collectDependabotFacts(ctx context.Context, owner, repo string, hasWorkflows bool, dbg DebugLogger) DependabotFacts {
+func (c *factCollector) collectDependabotFacts(ctx context.Context, owner, repo string, hasWorkflows bool, inv fileInventory, dbg DebugLogger) DependabotFacts {
 	repoFull := owner + "/" + repo
 	facts := DependabotFacts{
 		Path:         defaultDependabotPath,
@@ -104,8 +104,14 @@ func (c *factCollector) collectDependabotFacts(ctx context.Context, owner, repo 
 	// means the config is genuinely absent; an indeterminate error (timeout,
 	// rate limit, 5xx) means we could not determine presence, which is recorded
 	// as Unknown + a scan warning rather than silently reported as Missing.
+	//
+	// When the file inventory is complete, paths it never saw are skipped
+	// without a request — the listing already proved them absent.
 	var indeterminateErr error
 	for _, path := range []string{defaultDependabotPath, ".github/dependabot.yaml"} {
+		if inv.Complete && !inv.Has(path) {
+			continue
+		}
 		if dbg != nil {
 			dbg(repoFull, "GET /repos/"+repoFull+"/contents/"+path)
 		}
@@ -169,14 +175,40 @@ func parseDependabotContent(facts *DependabotFacts, fileContent *github.Reposito
 	}
 }
 
-func (c *factCollector) collectRenovateFacts(ctx context.Context, owner, repo string, hasWorkflows bool, dbg DebugLogger) RenovateFacts {
+// parseRenovateContent parses a fetched Renovate config into the facts,
+// recording a parse failure as Invalid rather than dropping it.
+func parseRenovateContent(facts *RenovateFacts, path, content string, dbg DebugLogger, repoFull string) {
+	config, err := parseRenovateConfig(content)
+	if err != nil {
+		facts.Invalid = fmt.Errorf("parse %s: %w", path, err)
+		if dbg != nil {
+			dbg(repoFull, "renovate config parse error: "+facts.Invalid.Error())
+		}
+		return
+	}
+	facts.Config = config
+	if dbg != nil {
+		dbg(repoFull, fmt.Sprintf("renovate config parsed: covers-actions=%v pin-digests=%v cooldown=%v extends=%v",
+			renovateCoversActions(config), renovatePinningConfigured(config), renovateCooldownConfigured(config), config.Extends))
+	}
+}
+
+func (c *factCollector) collectRenovateFacts(ctx context.Context, owner, repo string, hasWorkflows bool, inv fileInventory, dbg DebugLogger) RenovateFacts {
 	repoFull := owner + "/" + repo
 	facts := RenovateFacts{
 		HasWorkflows: hasWorkflows,
 	}
 
+	// The candidate paths are probed in Renovate's own precedence order, so the
+	// first hit wins exactly as Renovate itself would resolve it. A complete
+	// file inventory lets known-absent paths be skipped without a request —
+	// which is most of them, most of the time: a repository without Renovate
+	// used to pay all nine 404s on every scan.
 	var indeterminateErr error
 	for _, path := range renovateConfigPaths {
+		if inv.Complete && !inv.Has(path) {
+			continue
+		}
 		if dbg != nil {
 			dbg(repoFull, "GET /repos/"+repoFull+"/contents/"+path)
 		}
@@ -207,23 +239,7 @@ func (c *factCollector) collectRenovateFacts(ctx context.Context, owner, repo st
 		if dbg != nil {
 			dbg(repoFull, "found renovate config at "+path)
 		}
-
-		config, err := parseRenovateConfig(content)
-		if err != nil {
-			facts.Invalid = fmt.Errorf("parse %s: %w", path, err)
-			if dbg != nil {
-				dbg(repoFull, "renovate config parse error: "+facts.Invalid.Error())
-			}
-		} else {
-			facts.Config = config
-			coversActions := renovateCoversActions(config)
-			pinned := renovatePinningConfigured(config)
-			hasCooldown := renovateCooldownConfigured(config)
-			if dbg != nil {
-				dbg(repoFull, fmt.Sprintf("renovate config parsed: covers-actions=%v pin-digests=%v cooldown=%v extends=%v",
-					coversActions, pinned, hasCooldown, config.Extends))
-			}
-		}
+		parseRenovateContent(&facts, path, content, dbg, repoFull)
 		return facts
 	}
 

--- a/internal/scanner/updates_test.go
+++ b/internal/scanner/updates_test.go
@@ -173,7 +173,7 @@ func TestCollectDependabotFacts_DebugLogsKeyDecisions(t *testing.T) {
 		lines = append(lines, repo+"|"+msg)
 	}
 
-	facts := newTestFactCollector(s).collectDependabotFacts(context.Background(), "owner", "repo", true, dbg)
+	facts := newTestFactCollector(s).collectDependabotFacts(context.Background(), "owner", "repo", true, probeEverything(), dbg)
 	if facts.Config == nil {
 		t.Fatalf("expected parsed config, got %+v", facts)
 	}
@@ -202,7 +202,7 @@ func TestCollectRenovateFacts_DebugLogsKeyDecisions(t *testing.T) {
 		lines = append(lines, repo+"|"+msg)
 	}
 
-	facts := newTestFactCollector(s).collectRenovateFacts(context.Background(), "owner", "repo", true, dbg)
+	facts := newTestFactCollector(s).collectRenovateFacts(context.Background(), "owner", "repo", true, probeEverything(), dbg)
 	if facts.Config == nil {
 		t.Fatalf("expected parsed config, got %+v", facts)
 	}
@@ -227,7 +227,7 @@ func TestCollectRenovateFacts_IndeterminateErrorMarksUnknown(t *testing.T) {
 	handle500(mux, renovateServerPaths()...)
 
 	collector := newTestFactCollector(s)
-	facts := collector.collectRenovateFacts(context.Background(), "owner", "repo", true, nil)
+	facts := collector.collectRenovateFacts(context.Background(), "owner", "repo", true, probeEverything(), nil)
 
 	if facts.Missing {
 		t.Fatalf("Missing = true; an indeterminate error must not be reported as absent")
@@ -249,7 +249,7 @@ func TestCollectRenovateFacts_OneIndeterminatePathTaintsMissing(t *testing.T) {
 	handle404(mux, renovateServerPaths()[1:]...)
 
 	collector := newTestFactCollector(s)
-	facts := collector.collectRenovateFacts(context.Background(), "owner", "repo", true, nil)
+	facts := collector.collectRenovateFacts(context.Background(), "owner", "repo", true, probeEverything(), nil)
 
 	if facts.Missing || !facts.Unknown {
 		t.Fatalf("Missing=%v Unknown=%v, want Missing=false Unknown=true", facts.Missing, facts.Unknown)
@@ -261,7 +261,7 @@ func TestCollectRenovateFacts_AllNotFoundIsMissing(t *testing.T) {
 	handle404(mux, renovateServerPaths()...)
 
 	collector := newTestFactCollector(s)
-	facts := collector.collectRenovateFacts(context.Background(), "owner", "repo", true, nil)
+	facts := collector.collectRenovateFacts(context.Background(), "owner", "repo", true, probeEverything(), nil)
 
 	if !facts.Missing || facts.Unknown {
 		t.Fatalf("Missing=%v Unknown=%v, want Missing=true Unknown=false", facts.Missing, facts.Unknown)
@@ -279,7 +279,7 @@ func TestCollectDependabotFacts_IndeterminateErrorMarksUnknown(t *testing.T) {
 	)
 
 	collector := newTestFactCollector(s)
-	facts := collector.collectDependabotFacts(context.Background(), "owner", "repo", true, nil)
+	facts := collector.collectDependabotFacts(context.Background(), "owner", "repo", true, probeEverything(), nil)
 
 	if facts.Missing || !facts.Unknown {
 		t.Fatalf("Missing=%v Unknown=%v, want Missing=false Unknown=true", facts.Missing, facts.Unknown)
@@ -701,8 +701,8 @@ func collectAndEvaluateUpdateToolConfiguration(t *testing.T, s *Scanner) []Findi
 	hasWorkflows := len(workflows) > 0
 	facts := &ScanFacts{
 		Workflows:  workflows,
-		Dependabot: collector.collectDependabotFacts(context.Background(), "owner", "repo", hasWorkflows, nil),
-		Renovate:   collector.collectRenovateFacts(context.Background(), "owner", "repo", hasWorkflows, nil),
+		Dependabot: collector.collectDependabotFacts(context.Background(), "owner", "repo", hasWorkflows, probeEverything(), nil),
+		Renovate:   collector.collectRenovateFacts(context.Background(), "owner", "repo", hasWorkflows, probeEverything(), nil),
 	}
 	return evaluateUpdateToolConfigurationFacts(facts)
 }


### PR DESCRIPTION
**Stack #61, layer 3 of 9.**

The collectors probed every candidate config path with its own GET — 2 for Dependabot, 9 for Renovate — so a repo *without* Renovate (the common case) paid nine 404s per scan just to prove absence. At ~19 calls/repo, a 5,000/hr budget capped batch runs near 260 repos/hour with nearly half spent proving files don't exist.

A file-inventory collector lists the root plus `.github` (and `.gitlab` only when the root shows it) and the collectors skip paths the listings proved absent. Candidate order unchanged, so the first existing path wins exactly as Renovate resolves precedence.

**Measured live: 19-21 → 10-12 requests per scan, byte-identical findings.**

Correctness is one-directional by design — the inventory vouches for absence only when complete:
- listing failure → fall back to per-path probing
- listing at the contents API's **1,000-entry truncation cap** → fall back (can't distinguish "exactly 1000" from "truncated")
- root 404 → determinate empty repository, no fallback needed

A listing problem can cost speed, never invent a missing-config finding. The `Unknown`/incomplete semantics for indeterminate fetches are preserved (test updated to fail the listing too, so the fallback path is what's exercised).

The regression test **counts requests**: a Dependabot-only repo must finish update-tool collection in 2 listings + 1 fetch, and any probe the inventory should have prevented fails the test by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN
