### PR TITLE
Add the write-all-permissions rule (R6)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1408,12 +1408,14 @@ Why these are grouped and deferred:
 
 Candidates, in rough order of value:
 
-1. **Over-broad explicit workflow permissions (from R6).** `workflows/workflow-permissions` is
-   presence-only by design, so `permissions: write-all` — the broadest possible grant — produces a
-   clean pass at severity high. Either extend that rule to flag blanket grants, or add a separate rule.
-   Needs a decision on which scopes count as over-broad beyond `write-all`, since `contents: write` is
-   legitimate in plenty of workflows. `gasa-pass` already contains a milder instance:
-   `pr-target-replace-2.yaml` passes with `pull-requests: write`
+1. ~~**Over-broad explicit workflow permissions (from R6).**~~ **Done 2026-08-12** as a separate
+   rule, `workflows/write-all-permissions` (high). Separate rather than an extension because
+   `workflow-permissions` is a presence check by documented design, and "explicit but too broad" is
+   a coherent state the two rules should express independently. v1 flags only the literal
+   `write-all` (workflow or job level) — the one grant with no false-positive boundary to argue
+   about. Scoped writes like `pull-requests: write` stay legal; widening to combinations of scopes
+   would need the boundary decision this deliberately avoids. Fail fixture: `bad-write-all.yaml`
+   on `gasa-fail`, built so no other rule fires on it
 
 2. **`sha_pinning_required` repository setting (from R8).** Present in the `GET
    /repos/{owner}/{repo}/actions/permissions` response that `allowed-actions-policy` already parses. It

--- a/README.md
+++ b/README.md
@@ -373,13 +373,14 @@ The scanner runs the following checks against each repository. Findings are rate
 | [Pull Request Target](docs/rules/pull-request-target.md) | Workflows | Critical | `pull_request_target`, which should never be used in a public repo and is highly discouraged in a private repo |
 | [Action Version Pinning](docs/rules/action-version-pinning.md) | Workflows | High | Actions referenced by tag (`@v4`) or branch (`@main`) instead of commit SHA |
 | [Workflow Permissions](docs/rules/workflow-permissions.md) | Workflows | High | Workflows without an explicit `permissions` block, inheriting overly broad defaults |
+| [Write-All Workflow Permissions](docs/rules/write-all-permissions.md) | Workflows | High | Workflows granting `write-all`, the broadest possible `GITHUB_TOKEN` grant |
 | [Default Workflow Permissions](docs/rules/default-workflow-permissions.md) | Settings | High | Repository default `GITHUB_TOKEN` set to read-write instead of read-only |
 | [Allowed Actions Policy](docs/rules/allowed-actions-policy.md) | Settings | Medium | Repository allows all actions to run instead of restricting to trusted sources |
 | [Actions Can Approve PRs](docs/rules/actions-can-approve-prs.md) | Settings | Medium | Workflows can create and approve pull request reviews, bypassing required reviews |
 | [Fork PR Workflow Approval](docs/rules/fork-pr-workflow-approval.md) | Settings | High | External contributors can trigger fork PR workflows without maintainer approval |
 | [Update Tool Configuration](docs/rules/update-tool-configuration.md) | Updates | Medium | No Dependabot or Renovate config, invalid config, or missing `github-actions` coverage |
 | [Update Tool GitHub Actions Cooldown](docs/rules/update-tool-actions-cooldown.md) | Updates | Low | Neither Dependabot nor Renovate sets a cooldown delay for `github-actions` updates |
-| [Renovate GitHub Actions Pinning](docs/rules/update-tool-actions-pinning.md) | Updates | Medium | Renovate is not configured to pin actions to immutable commit SHAs (Dependabot has no equivalent option) |
+| [Update Tool GitHub Actions Pinning](docs/rules/update-tool-actions-pinning.md) | Updates | Medium | No update tool will keep action commit SHAs current — Renovate without digest pinning and no Dependabot `github-actions` entry |
 
 ## Build
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -191,7 +191,7 @@ func TestPrintRulesTable(t *testing.T) {
 		printRulesTable()
 	})
 	checks := []string{
-		"Available rules: 10",
+		"Available rules: 11",
 		"workflows/pull-request-target",
 		"actions/permissions/allowed-actions-policy",
 		"updates/update-tool-configuration",
@@ -214,8 +214,8 @@ func TestPrintRulesJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(output), &rules); err != nil {
 		t.Fatalf("json.Unmarshal() error: %v\noutput=%s", err, output)
 	}
-	if len(rules) != 10 {
-		t.Fatalf("len(rules) = %d, want 10", len(rules))
+	if len(rules) != 11 {
+		t.Fatalf("len(rules) = %d, want 11", len(rules))
 	}
 	if rules[0].Name == "" {
 		t.Fatal("expected populated rule names")

--- a/docs/rules/write-all-permissions.md
+++ b/docs/rules/write-all-permissions.md
@@ -1,0 +1,126 @@
+---
+name: workflows/write-all-permissions
+order: 11
+title: Write-All Workflow Permissions
+category: Workflows
+severity: high
+aliases: [write-all-permissions, write-all]
+description: workflows grant `write-all` permissions, the broadest possible GITHUB_TOKEN grant
+messages:
+  write-all:
+    title: "Workflow grants write-all permissions {{.Where}}"
+    description: >-
+      This workflow declares `permissions: write-all` {{.Where}}, which grants the
+      GITHUB_TOKEN write access to every scope — contents, packages, pull
+      requests, issues, deployments, and more. A compromised step or action in
+      this workflow can use all of it.
+    fix: >-
+      Replace `write-all` with the minimal scopes the jobs actually need. Start
+      from `permissions: {}` and add individual scopes such as `contents: read`
+      or `issues: write` one at a time.
+  pass:
+    title: No workflow grants write-all permissions
+    description: >-
+      No parsed workflow declares `write-all` permissions at the workflow or job
+      level.
+---
+
+# Write-All Workflow Permissions
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Rule name** | `workflows/write-all-permissions` |
+| **Aliases** | `write-all-permissions`, `write-all` |
+
+## What it checks
+
+Whether any workflow declares `permissions: write-all` — at the workflow level
+or on any individual job.
+
+## How this differs from `workflow-permissions`
+
+The [`workflow-permissions`](workflow-permissions.md) rule is deliberately a
+**presence** check: it verifies that permissions are explicit, not that they are
+minimal, and its documentation says so. That leaves a gap this rule closes: a
+workflow with `permissions: write-all` passes the presence check while granting
+the single broadest token possible — the exact thing the GitHub Actions
+hardening guidance warns against.
+
+The two rules are separate on purpose. Passing `workflow-permissions` while
+failing this rule is a coherent, common state: the permissions are explicit but
+far too broad.
+
+## How the scanner evaluates it
+
+For every workflow that parses and defines at least one job, the scanner
+inspects:
+
+- the top-level `permissions` value
+- each `jobs.<job_id>.permissions` value
+
+Any of them equal to the string `write-all` produces one high finding naming
+the workflow (and the job, for job-level grants).
+
+Deliberate v1 scope: only the literal `write-all` is flagged. An explicit map
+that happens to grant many scopes (`contents: write`, `issues: write`, …) is
+not, because individual write scopes are routinely legitimate — deciding which
+combinations count as over-broad needs a false-positive boundary that
+`write-all` does not. `read-all` is not flagged: it grants no write access.
+
+## Why this matters
+
+`write-all` gives the workflow's GITHUB_TOKEN write access to every permission
+scope GitHub offers. If any step, action, or transitively-included script in
+the workflow is compromised, the attacker holds all of it — push access,
+package publishing, release editing, PR approval. Minimal scopes exist to make
+that blast radius small.
+
+## Bad examples
+
+```yaml
+on: push
+
+permissions: write-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: make build
+```
+
+```yaml
+on: push
+
+permissions: {}
+
+jobs:
+  release:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - run: make release
+```
+
+## Good example
+
+```yaml
+on: push
+
+permissions: {}
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - run: make release
+```
+
+## References
+
+- `internal/scanner/workflow.go`
+- [Controlling permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
+- [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -47,6 +47,7 @@ var runFuncs = map[string]func(*ScanFacts) []Finding{
 	ruleNamePullRequestTarget:          evaluateDangerousWorkflowRule,
 	ruleNameActionVersionPinning:       evaluateActionVersionPinningRule,
 	ruleNameWorkflowPermissions:        evaluateWorkflowPermissionsRule,
+	ruleNameWriteAllPermissions:        evaluateWriteAllPermissionsRule,
 	ruleNameAllowedActionsPolicy:       evaluateAllowedActionsPolicyRule,
 	ruleNameDefaultWorkflowPermissions: evaluateDefaultWorkflowPermissionsRule,
 	ruleNameActionsCanApprovePRs:       evaluateActionsCanApprovePRsRule,
@@ -279,6 +280,8 @@ func successFindingForRule(r rule, facts *ScanFacts, cfg *Config) *Finding {
 	case ruleNameActionVersionPinning:
 		return successMessage(r.Name, severity, "Workflow files", "pass", nil)
 	case ruleNameWorkflowPermissions:
+		return successMessage(r.Name, severity, "Workflow files", "pass", nil)
+	case ruleNameWriteAllPermissions:
 		return successMessage(r.Name, severity, "Workflow files", "pass", nil)
 	case ruleNameAllowedActionsPolicy:
 		return allowedActionsSuccessFinding(r.Name, severity, facts)
@@ -687,6 +690,34 @@ func evaluateWorkflowPermissionsRule(facts *ScanFacts) []Finding {
 			File:        wf.Path,
 			Remediation: msg.Fix,
 		})
+	}
+	return findings
+}
+
+// evaluateWriteAllPermissionsRule flags `permissions: write-all` at the
+// workflow or job level. Deliberately narrow: only the literal write-all is
+// unambiguous enough to flag without a false-positive boundary — individual
+// write scopes are routinely legitimate, and workflow-permissions already
+// covers the missing-permissions case. Jobless files are skipped for the same
+// reason workflow-permissions skips them: they are not runnable workflows, and
+// the collector already reports them as an incomplete-scan warning.
+func evaluateWriteAllPermissionsRule(facts *ScanFacts) []Finding {
+	var findings []Finding
+	for _, wf := range facts.Workflows {
+		if !wf.Valid || len(wf.Workflow.Jobs) == 0 {
+			continue
+		}
+		for _, grant := range writeAllGrants(wf.Workflow) {
+			msg := ruleMessage(ruleNameWriteAllPermissions, "write-all", map[string]string{"Where": grant.where})
+			findings = append(findings, Finding{
+				ID:          grant.findingID(wf.Path),
+				Severity:    SeverityHigh,
+				Title:       msg.Title,
+				Description: msg.Description,
+				File:        wf.Path,
+				Remediation: msg.Fix,
+			})
+		}
 	}
 	return findings
 }

--- a/internal/scanner/rules_test.go
+++ b/internal/scanner/rules_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestAvailableRules_Count(t *testing.T) {
 	rules := AvailableRules()
-	if got := len(rules); got != 10 {
-		t.Errorf("AvailableRules() returned %d rules, want 10", got)
+	if got := len(rules); got != 11 {
+		t.Errorf("AvailableRules() returned %d rules, want 11", got)
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -26,6 +26,7 @@ const (
 	ruleNamePullRequestTarget          = "workflows/pull-request-target"
 	ruleNameActionVersionPinning       = "workflows/action-version-pinning"
 	ruleNameWorkflowPermissions        = "workflows/workflow-permissions"
+	ruleNameWriteAllPermissions        = "workflows/write-all-permissions"
 	ruleNameAllowedActionsPolicy       = "actions/permissions/allowed-actions-policy"
 	ruleNameDefaultWorkflowPermissions = "actions/permissions/workflow/default-workflow-permissions"
 	ruleNameActionsCanApprovePRs       = "actions/permissions/workflow/actions-can-approve-prs"

--- a/internal/scanner/workflow.go
+++ b/internal/scanner/workflow.go
@@ -363,3 +363,51 @@ func sanitizeID(s string) string {
 	s = strings.ReplaceAll(s, "@", "-")
 	return s
 }
+
+// writeAllGrant records one place a workflow granted write-all: the workflow
+// level (job == "") or a named job.
+type writeAllGrant struct {
+	job   string
+	where string
+}
+
+// findingID keeps write-all findings unique per grant site, so a workflow-level
+// grant and a job-level grant in the same file never collide in dedupe.
+func (g writeAllGrant) findingID(path string) string {
+	if g.job == "" {
+		return "write-all-" + path
+	}
+	return "write-all-" + path + "-" + sanitizeID(g.job)
+}
+
+// writeAllGrants returns every write-all permission grant in the workflow, in
+// deterministic order: the workflow level first, then jobs sorted by name (job
+// iteration order is a map walk otherwise, and findings ordering must be
+// stable).
+func writeAllGrants(workflow *WorkflowFile) []writeAllGrant {
+	var grants []writeAllGrant
+	if isWriteAll(workflow.Permissions) {
+		grants = append(grants, writeAllGrant{where: "at the workflow level"})
+	}
+
+	jobNames := make([]string, 0, len(workflow.Jobs))
+	for name := range workflow.Jobs {
+		jobNames = append(jobNames, name)
+	}
+	sort.Strings(jobNames)
+	for _, name := range jobNames {
+		if isWriteAll(workflow.Jobs[name].Permissions) {
+			grants = append(grants, writeAllGrant{job: name, where: fmt.Sprintf("on job %q", name)})
+		}
+	}
+	return grants
+}
+
+// isWriteAll reports whether a permissions value is the literal write-all
+// grant. Only the scalar form exists — `permissions: write-all` — so a map
+// value can never match. read-all is deliberately not matched: it grants no
+// write access.
+func isWriteAll(permissions interface{}) bool {
+	s, ok := permissions.(string)
+	return ok && s == "write-all"
+}

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -334,3 +334,64 @@ func TestSanitizeID(t *testing.T) {
 		t.Fatalf("sanitizeID() = %s, want %s", got, want)
 	}
 }
+
+// write-all is the broadest possible grant, and it PASSES workflow-permissions
+// by design (that rule checks presence, not breadth). This rule closes the gap.
+func TestEvaluateWriteAllPermissionsRule(t *testing.T) {
+	parse := func(t *testing.T, content string) []WorkflowFact {
+		t.Helper()
+		workflow := &WorkflowFile{}
+		if err := yaml.Unmarshal([]byte(content), workflow); err != nil {
+			t.Fatalf("yaml.Unmarshal() error: %v", err)
+		}
+		return []WorkflowFact{{Path: ".github/workflows/ci.yml", Content: content, Workflow: workflow, Valid: true}}
+	}
+
+	t.Run("workflow level", func(t *testing.T) {
+		facts := &ScanFacts{Workflows: parse(t, "on: push\npermissions: write-all\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n")}
+		findings := evaluateWriteAllPermissionsRule(facts)
+		if len(findings) != 1 || findings[0].ID != "write-all-.github/workflows/ci.yml" {
+			t.Fatalf("findings = %+v, want one workflow-level finding", findings)
+		}
+		if findings[0].Severity != SeverityHigh {
+			t.Fatalf("severity = %q, want high", findings[0].Severity)
+		}
+		// The same workflow must PASS the presence check: explicit-but-broad is
+		// exactly the split the two rules exist to express.
+		if presence := evaluateWorkflowPermissionsRule(facts); len(presence) != 0 {
+			t.Fatalf("workflow-permissions findings = %+v, want none for explicit permissions", presence)
+		}
+	})
+
+	t.Run("job level, deterministic order", func(t *testing.T) {
+		content := "on: push\npermissions: {}\njobs:\n  zeta:\n    permissions: write-all\n    runs-on: ubuntu-latest\n    steps: [{run: echo hi}]\n  alpha:\n    permissions: write-all\n    runs-on: ubuntu-latest\n    steps: [{run: echo hi}]\n"
+		findings := evaluateWriteAllPermissionsRule(&ScanFacts{Workflows: parse(t, content)})
+		if len(findings) != 2 {
+			t.Fatalf("findings = %+v, want two job-level findings", findings)
+		}
+		if findings[0].ID != "write-all-.github/workflows/ci.yml-alpha" || findings[1].ID != "write-all-.github/workflows/ci.yml-zeta" {
+			t.Fatalf("job findings must be name-sorted for deterministic output, got %q then %q", findings[0].ID, findings[1].ID)
+		}
+	})
+
+	t.Run("read-all and scoped writes are not flagged", func(t *testing.T) {
+		for _, content := range []string{
+			"on: push\npermissions: read-all\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps: [{run: echo hi}]\n",
+			"on: push\npermissions:\n  contents: write\n  issues: write\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps: [{run: echo hi}]\n",
+		} {
+			if findings := evaluateWriteAllPermissionsRule(&ScanFacts{Workflows: parse(t, content)}); len(findings) != 0 {
+				t.Fatalf("findings = %+v, want none for:\n%s", findings, content)
+			}
+		}
+	})
+
+	t.Run("jobless and unparsed files are skipped", func(t *testing.T) {
+		facts := &ScanFacts{Workflows: []WorkflowFact{
+			{Path: "a.yml", Valid: false, Content: "permissions: write-all"},
+			{Path: "b.yml", Valid: true, Workflow: &WorkflowFile{Permissions: "write-all"}},
+		}}
+		if findings := evaluateWriteAllPermissionsRule(facts); len(findings) != 0 {
+			t.Fatalf("findings = %+v, want none", findings)
+		}
+	})
+}

--- a/testdata/e2e/expected/gasa-fail-private.golden.json
+++ b/testdata/e2e/expected/gasa-fail-private.golden.json
@@ -61,6 +61,12 @@
       "id": "success-workflows-workflow-permissions",
       "severity": "high",
       "success": true
+    },
+    {
+      "rule": "workflows/write-all-permissions",
+      "id": "success-workflows-write-all-permissions",
+      "severity": "high",
+      "success": true
     }
   ]
 }

--- a/testdata/e2e/expected/gasa-fail.golden.json
+++ b/testdata/e2e/expected/gasa-fail.golden.json
@@ -97,6 +97,12 @@
       "id": "no-permissions-.github/workflows/bad-pull-request-target.yaml",
       "severity": "high",
       "success": false
+    },
+    {
+      "rule": "workflows/write-all-permissions",
+      "id": "write-all-.github/workflows/bad-write-all.yaml",
+      "severity": "high",
+      "success": false
     }
   ]
 }

--- a/testdata/e2e/expected/gasa-pass.golden.json
+++ b/testdata/e2e/expected/gasa-pass.golden.json
@@ -61,6 +61,12 @@
       "id": "success-workflows-workflow-permissions",
       "severity": "high",
       "success": true
+    },
+    {
+      "rule": "workflows/write-all-permissions",
+      "id": "success-workflows-write-all-permissions",
+      "severity": "high",
+      "success": true
     }
   ]
 }

--- a/testdata/e2e/fixtures/gasa-fail/files/.github/workflows/bad-write-all.yaml
+++ b/testdata/e2e/fixtures/gasa-fail/files/.github/workflows/bad-write-all.yaml
@@ -1,0 +1,21 @@
+# Deliberately grants `write-all` — the broadest possible GITHUB_TOKEN grant —
+# so the gasa write-all-permissions rule has a real failing case. Everything
+# else about this file is deliberately clean: permissions are explicit (so the
+# workflow-permissions rule passes), there are no `uses:` references (so the
+# pinning rule sees nothing), and the trigger is plain push. The step body is
+# inert, which matters: a run of this workflow genuinely holds a write-all
+# token.
+name: Bad Write All
+
+on:
+  push:
+    branches: [main]
+
+permissions: write-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inert fixture step
+        run: echo "inert fixture step — no commands are executed in this repository"


### PR DESCRIPTION
**Stack #61, layer 4 of 9.** First of the three Phase 13 rules.

`permissions: write-all` is the broadest possible `GITHUB_TOKEN` grant — write to every scope — and it produced a **clean pass**, because `workflow-permissions` is a presence check by documented design. An operator reading "Workflow permissions are explicit" over a write-all grant was told the opposite of the truth that matters.

**Design decisions to review:**
- **Separate rule** (`workflows/write-all-permissions`, high), not a widening of `workflow-permissions`: "explicit but maximally broad" and "not explicit" are different findings with different fixes, and a workflow can be in the first state and not the second.
- **v1 boundary = the literal `write-all` only**, workflow or job level. Scoped writes (`contents: write`) are routinely legitimate; deciding which *combinations* are over-broad needs a false-positive boundary that `write-all` doesn't. `read-all` not flagged (no write access). Jobless files skipped, same as `workflow-permissions`.
- Job-level findings emit in **name-sorted order** (job iteration is a map walk; a test fails if determinism regresses).

Fixture: new `bad-write-all.yaml` on gasa-fail, built so **no other rule fires on it** — permissions present, no `uses:`, plain push trigger, inert body (not cosmetic: a run genuinely holds a write-all token). The golden diff shows every pre-existing entry unchanged, which is the proof.

Also fixes the README rules-table row that still described the pinning rule as Renovate-only (stale since R22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN
