### PR TITLE
Add the sha-pinning-required rule (R8)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1417,12 +1417,14 @@ Candidates, in rough order of value:
    would need the boundary decision this deliberately avoids. Fail fixture: `bad-write-all.yaml`
    on `gasa-fail`, built so no other rule fires on it
 
-2. **`sha_pinning_required` repository setting (from R8).** Present in the `GET
-   /repos/{owner}/{repo}/actions/permissions` response that `allowed-actions-policy` already parses. It
-   is GitHub's enforcement of "require actions pinned to a full-length commit SHA". Complements
-   `action-version-pinning` precisely: that rule proves the files are pinned today, this setting
-   prevents an unpinned ref landing tomorrow. Fixture consequence: both repos currently report `false`,
-   so `gasa-pass` needs the setting enabled before it could pass
+2. ~~**`sha_pinning_required` repository setting (from R8).**~~ **Done 2026-08-12** as
+   `actions/permissions/sha-pinning-required` (medium). Zero additional API calls — the flag rides
+   in the /actions/permissions response the allowed-actions rule already reads. An absent value
+   (older GHES) reports undetermined rather than staying silent, and a transient settings failure
+   marks it undetermined alongside the other four settings rules. Fixture states applied live:
+   enforcement ON for `gasa-pass` and `gasa-fail-private` (all their workflows are SHA-pinned, so
+   nothing breaks), OFF for `gasa-fail`. The fixtures tool now declares, verifies, and applies the
+   setting
 
 3. **`pull_request_creation_policy` (from R16).** Present on the repository object the scanner already
    fetches. `gasa-fail` reports `collaborators_only`, `gasa-pass` reports `all`. It is the control that

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ The scanner runs the following checks against each repository. Findings are rate
 | [Allowed Actions Policy](docs/rules/allowed-actions-policy.md) | Settings | Medium | Repository allows all actions to run instead of restricting to trusted sources |
 | [Actions Can Approve PRs](docs/rules/actions-can-approve-prs.md) | Settings | Medium | Workflows can create and approve pull request reviews, bypassing required reviews |
 | [Fork PR Workflow Approval](docs/rules/fork-pr-workflow-approval.md) | Settings | High | External contributors can trigger fork PR workflows without maintainer approval |
+| [SHA Pinning Required](docs/rules/sha-pinning-required.md) | Settings | Medium | Repository does not enforce full-length commit SHA pinning for actions |
 | [Update Tool Configuration](docs/rules/update-tool-configuration.md) | Updates | Medium | No Dependabot or Renovate config, invalid config, or missing `github-actions` coverage |
 | [Update Tool GitHub Actions Cooldown](docs/rules/update-tool-actions-cooldown.md) | Updates | Low | Neither Dependabot nor Renovate sets a cooldown delay for `github-actions` updates |
 | [Update Tool GitHub Actions Pinning](docs/rules/update-tool-actions-pinning.md) | Updates | Medium | No update tool will keep action commit SHAs current — Renovate without digest pinning and no Dependabot `github-actions` entry |

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -191,7 +191,7 @@ func TestPrintRulesTable(t *testing.T) {
 		printRulesTable()
 	})
 	checks := []string{
-		"Available rules: 11",
+		"Available rules: 12",
 		"workflows/pull-request-target",
 		"actions/permissions/allowed-actions-policy",
 		"updates/update-tool-configuration",
@@ -214,8 +214,8 @@ func TestPrintRulesJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(output), &rules); err != nil {
 		t.Fatalf("json.Unmarshal() error: %v\noutput=%s", err, output)
 	}
-	if len(rules) != 11 {
-		t.Fatalf("len(rules) = %d, want 11", len(rules))
+	if len(rules) != 12 {
+		t.Fatalf("len(rules) = %d, want 12", len(rules))
 	}
 	if rules[0].Name == "" {
 		t.Fatal("expected populated rule names")

--- a/docs/rules/sha-pinning-required.md
+++ b/docs/rules/sha-pinning-required.md
@@ -1,0 +1,105 @@
+---
+name: actions/permissions/sha-pinning-required
+order: 12
+title: SHA Pinning Required
+category: Settings
+severity: medium
+aliases: [sha-pinning-required, sha-pinning]
+description: repository does not require actions to be pinned to a full-length commit SHA
+messages:
+  not-required:
+    title: Actions are not required to be pinned to a commit SHA
+    description: >-
+      The repository does not enforce full-length commit SHA pinning for
+      actions, so a workflow change that references a mutable tag or branch can
+      be merged and will run. Even a repository whose workflows are all pinned
+      today has nothing stopping an unpinned reference landing tomorrow.
+    fix: >-
+      Enable 'Require actions to be pinned to a full-length commit SHA' in
+      Settings > Actions > General. Pin every existing workflow reference first
+      — enforcement blocks unpinned workflows from running.
+  pass-disabled:
+    title: SHA pinning enforcement is moot — Actions are disabled
+    description: >-
+      GitHub Actions are disabled for this repository, so no workflow can run
+      regardless of how its actions are referenced.
+  pass:
+    title: Actions are required to be pinned to a commit SHA
+    description: >-
+      The repository enforces full-length commit SHA pinning, so an unpinned
+      action reference cannot run even if one is merged.
+---
+
+# SHA Pinning Required
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Rule name** | `actions/permissions/sha-pinning-required` |
+| **Aliases** | `sha-pinning-required`, `sha-pinning` |
+| **Auth required** | Yes |
+| **Minimum fine-grained permission** | `Administration: Read` |
+| **Classic PAT** | `repo` |
+
+## What it checks
+
+Whether the repository setting **Require actions to be pinned to a full-length
+commit SHA** is enabled.
+
+## How this differs from `action-version-pinning`
+
+[`action-version-pinning`](action-version-pinning.md) (high) proves the
+workflow files are pinned **today**. This rule checks the setting that stops an
+unpinned reference from ever running **tomorrow** — GitHub refuses to run a
+workflow referencing a mutable tag or branch while enforcement is on. The two
+are complementary: pinned files without enforcement drift; enforcement without
+pinned files blocks the existing workflows, which is why the remediation says
+to pin first.
+
+## How the scanner evaluates it
+
+The setting arrives in the same `GET /repos/{owner}/{repo}/actions/permissions`
+response the [allowed-actions policy](allowed-actions-policy.md) rule already
+reads, so this rule costs no additional API call.
+
+- if `sha_pinning_required == false`, it creates a medium finding
+- if `sha_pinning_required == true`, the rule passes
+- if Actions is disabled (`enabled == false`), the rule passes — nothing can
+  run, pinned or otherwise. This requires GitHub to have actually reported
+  `enabled: false`; a settings read that failed is undetermined, not disabled
+- if GitHub reports no `sha_pinning_required` value at all (for example an
+  older GitHub Enterprise Server), the rule reports an informational
+  `undetermined-*` finding rather than staying silent — an unreadable setting
+  is unknown, not clean
+
+This rule uses the repository Actions settings API, so full scans need
+fine-grained `Administration: Read` repository permission, or classic PAT
+`repo`.
+
+## Why this matters
+
+Pinning to a full-length commit SHA is the only immutable action reference, but
+file-level pinning is a convention until this setting makes it a rule. With
+enforcement on, a pull request that introduces `uses: some/action@v3` produces
+a workflow GitHub will not run — the drift is caught at the platform, not in
+review.
+
+## Bad example
+
+```text
+Settings > Actions > General
+  Require actions to be pinned to a full-length commit SHA: disabled
+```
+
+## Good example
+
+```text
+Settings > Actions > General
+  Require actions to be pinned to a full-length commit SHA: enabled
+```
+
+## References
+
+- `internal/scanner/settings.go`
+- [Get GitHub Actions permissions for a repository](https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-a-repository)
+- [Security hardening for GitHub Actions: Using third-party actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

--- a/internal/scanner/facts.go
+++ b/internal/scanner/facts.go
@@ -76,6 +76,7 @@ const (
 	settingAllowedActions      = "allowed-actions policy"
 	settingWorkflowPermissions = "workflow permissions"
 	settingForkPRApproval      = "fork-PR contributor approval"
+	settingSHAPinning          = "SHA pinning requirement"
 )
 
 // markUndetermined records that a setting could not be read, and why.

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -52,6 +52,7 @@ var runFuncs = map[string]func(*ScanFacts) []Finding{
 	ruleNameDefaultWorkflowPermissions: evaluateDefaultWorkflowPermissionsRule,
 	ruleNameActionsCanApprovePRs:       evaluateActionsCanApprovePRsRule,
 	ruleNameForkPRContributorApproval:  evaluateForkPRContributorApprovalRule,
+	ruleNameSHAPinningRequired:         evaluateSHAPinningRequiredRule,
 	ruleNameUpdateToolConfiguration:    evaluateUpdateToolConfigurationRule,
 	ruleNameUpdateToolActionsCooldown:  evaluateUpdateToolActionsCooldownRule,
 	ruleNameUpdateToolActionsPinning:   evaluateUpdateToolActionsPinningRule,
@@ -291,6 +292,8 @@ func successFindingForRule(r rule, facts *ScanFacts, cfg *Config) *Finding {
 		return actionsApprovePRsSuccessFinding(r.Name, severity, facts)
 	case ruleNameForkPRContributorApproval:
 		return forkPRApprovalSuccessFinding(r.Name, severity, facts)
+	case ruleNameSHAPinningRequired:
+		return shaPinningRequiredSuccessFinding(r.Name, severity, facts)
 	case ruleNameUpdateToolConfiguration:
 		return updateToolConfigurationSuccessFinding(r.Name, severity, facts)
 	case ruleNameUpdateToolActionsCooldown:
@@ -398,6 +401,22 @@ func forkPRApprovalSuccessFinding(ruleName, severity string, facts *ScanFacts) *
 		return nil
 	}
 	return successMessage(ruleName, severity, "Repository Actions settings", "pass-all-external", nil)
+}
+
+func shaPinningRequiredSuccessFinding(ruleName, severity string, facts *ScanFacts) *Finding {
+	if !actionsSettingsEnabled(facts) {
+		if !actionsObservedDisabled(facts) {
+			// The settings were never read. Claiming they are safely disabled
+			// would invent an observation.
+			return nil
+		}
+		return successMessage(ruleName, severity, "Repository Actions settings", "pass-disabled", nil)
+	}
+	permissions := facts.ActionsSettings.Permissions
+	if permissions.SHAPinningRequired == nil || !*permissions.SHAPinningRequired {
+		return nil
+	}
+	return successMessage(ruleName, severity, "Repository Actions settings", "pass", nil)
 }
 
 func updateToolConfigurationSuccessFinding(ruleName, severity string, facts *ScanFacts) *Finding {
@@ -827,6 +846,39 @@ func evaluateForkPRContributorApprovalRule(facts *ScanFacts) []Finding {
 		Description: msg.Description,
 		Remediation: msg.Fix,
 	})
+
+	return findings
+}
+
+// evaluateSHAPinningRequiredRule checks the repository setting that makes SHA
+// pinning an enforced rule rather than a convention. It rides in the same
+// /actions/permissions response the allowed-actions rule reads, so it costs no
+// additional API call. Complements action-version-pinning: that rule proves the
+// files are pinned today, this setting stops an unpinned reference running
+// tomorrow.
+func evaluateSHAPinningRequiredRule(facts *ScanFacts) []Finding {
+	findings := make([]Finding, 0)
+	findings = appendSettingsAccessFinding(findings, facts)
+
+	if undetermined := undeterminedFindingFor(facts, ruleNameSHAPinningRequired, settingSHAPinning); undetermined != nil {
+		return append(findings, *undetermined)
+	}
+
+	permissions := facts.ActionsSettings.Permissions
+	if !actionsSettingsEnabled(facts) || permissions.SHAPinningRequired == nil {
+		return findings
+	}
+
+	if !*permissions.SHAPinningRequired {
+		msg := ruleMessage(ruleNameSHAPinningRequired, "not-required", nil)
+		findings = append(findings, Finding{
+			ID:          findingIDSHAPinningNotRequired,
+			Severity:    SeverityMedium,
+			Title:       msg.Title,
+			Description: msg.Description,
+			Remediation: msg.Fix,
+		})
+	}
 
 	return findings
 }

--- a/internal/scanner/rules_test.go
+++ b/internal/scanner/rules_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestAvailableRules_Count(t *testing.T) {
 	rules := AvailableRules()
-	if got := len(rules); got != 11 {
-		t.Errorf("AvailableRules() returned %d rules, want 11", got)
+	if got := len(rules); got != 12 {
+		t.Errorf("AvailableRules() returned %d rules, want 12", got)
 	}
 }
 
@@ -133,8 +133,8 @@ func TestResolveRules_BySeverity(t *testing.T) {
 		}
 	}
 
-	if len(resolved) != 5 {
-		t.Fatalf("resolved %d rules, want 5", len(resolved))
+	if len(resolved) != 6 {
+		t.Fatalf("resolved %d rules, want 6", len(resolved))
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -34,6 +34,7 @@ const (
 	ruleNameUpdateToolConfiguration    = "updates/update-tool-configuration"
 	ruleNameUpdateToolActionsCooldown  = "updates/update-tool-actions-cooldown"
 	ruleNameUpdateToolActionsPinning   = "updates/update-tool-actions-pinning"
+	ruleNameSHAPinningRequired         = "actions/permissions/sha-pinning-required"
 
 	// Finding IDs
 	findingIDSettingsCheckFailed      = "settings-check-failed"
@@ -55,6 +56,7 @@ const (
 	findingIDDefaultPermissionsWrite = "settings-default-permissions-write"
 	findingIDActionsCanApprovePRs    = "settings-actions-can-approve-prs"
 	findingIDForkPRTooPermissive     = "settings-fork-pr-contributor-approval-too-permissive"
+	findingIDSHAPinningNotRequired   = "settings-sha-pinning-not-required"
 
 	// GitHub Actions permission values
 	actionsAllowedAll         = "all"
@@ -286,7 +288,7 @@ func buildFixURL(f Finding, owner, repo, defaultBranch string) string {
 		return settingsURL
 	case findingIDDefaultPermissionsWrite, findingIDActionsCanApprovePRs:
 		return settingsURL
-	case findingIDForkPRTooPermissive:
+	case findingIDForkPRTooPermissive, findingIDSHAPinningNotRequired:
 		return settingsURL
 	case findingIDNoUpdateTool:
 		return fmt.Sprintf("%s/new/%s?filename=%s", repoURL, pathEscapeSegments(defaultBranch), url.QueryEscape(defaultDependabotPath))

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -447,7 +447,7 @@ func TestScanRepo_EndToEndMixedFindings(t *testing.T) {
 	}})
 	workflow := "on: pull_request_target\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n"
 	handleJSON(mux, "/repos/owner/repo/contents/.github/workflows/ci.yml", encodedContent(".github/workflows/ci.yml", workflow))
-	handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "all"})
+	handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "all", "sha_pinning_required": false})
 	handleJSON(mux, "/repos/owner/repo/actions/permissions/workflow", map[string]any{"default_workflow_permissions": "write", "can_approve_pull_request_reviews": true})
 	handleJSON(mux, "/repos/owner/repo/actions/permissions/fork-pr-contributor-approval", map[string]any{"approval_policy": "first_time_contributors"})
 	depConfig := "version: 2\nupdates:\n  - package-ecosystem: gomod\n    directory: /\n    schedule:\n      interval: weekly\n"
@@ -476,8 +476,8 @@ func TestScanRepo_EndToEndMixedFindings(t *testing.T) {
 	if result.RepoFullName != "owner/repo" {
 		t.Fatalf("RepoFullName = %s", result.RepoFullName)
 	}
-	if len(result.Findings) != 8 {
-		t.Fatalf("len(findings) = %d, want 8\nfindings=%+v", len(result.Findings), result.Findings)
+	if len(result.Findings) != 9 {
+		t.Fatalf("len(findings) = %d, want 9\nfindings=%+v", len(result.Findings), result.Findings)
 	}
 
 	wantIDs := map[string]bool{
@@ -488,6 +488,7 @@ func TestScanRepo_EndToEndMixedFindings(t *testing.T) {
 		"settings-default-permissions-write":                    false,
 		"settings-actions-can-approve-prs":                      false,
 		"settings-fork-pr-contributor-approval-too-permissive":  false,
+		"settings-sha-pinning-not-required":                     false,
 		"update-tool-missing-actions":                           false,
 	}
 	for _, finding := range result.Findings {
@@ -566,7 +567,7 @@ func TestScanRepoWithOptions_IncludeSuccess(t *testing.T) {
 	}})
 	workflow := "on: pull_request\npermissions: {}\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@0123456789012345678901234567890123456789\n"
 	handleJSON(mux, "/repos/owner/repo/contents/.github/workflows/ci.yml", encodedContent(".github/workflows/ci.yml", workflow))
-	handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "selected"})
+	handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "selected", "sha_pinning_required": true})
 	handleJSON(mux, "/repos/owner/repo/actions/permissions/workflow", map[string]any{"default_workflow_permissions": "read", "can_approve_pull_request_reviews": false})
 	handleJSON(mux, "/repos/owner/repo/actions/permissions/fork-pr-contributor-approval", map[string]any{"approval_policy": "all_external_contributors"})
 	depConfig := "version: 2\nupdates:\n  - package-ecosystem: github-actions\n    directory: /\n    schedule:\n      interval: weekly\n    cooldown:\n      default-days: 7\n  - package-ecosystem: gomod\n    directory: /\n    schedule:\n      interval: weekly\n"

--- a/internal/scanner/settings.go
+++ b/internal/scanner/settings.go
@@ -59,15 +59,7 @@ func (c *factCollector) collectActionsSettingsFacts(ctx context.Context, owner, 
 	}
 
 	facts.Permissions = permissions
-	// Actions is enabled but GitHub did not report a policy value. Observed when
-	// an org or enterprise policy governs the repository. Without this the rule
-	// would emit neither a finding nor a success and vanish from the report.
-	if permissions.AllowedActions == nil && (permissions.Enabled == nil || *permissions.Enabled) {
-		facts.markUndetermined(settingAllowedActions, "GitHub did not report an allowed-actions value for this repository")
-		if dbg != nil {
-			dbg(repoFull, "actions/permissions: allowed_actions absent — undetermined")
-		}
-	}
+	markAbsentPermissionFields(&facts, permissions, repoFull, dbg)
 	if permissions.Enabled != nil && !*permissions.Enabled {
 		if dbg != nil {
 			dbg(repoFull, "actions disabled for this repo — skipping workflow/fork-pr settings")
@@ -82,6 +74,30 @@ func (c *factCollector) collectActionsSettingsFacts(ctx context.Context, owner, 
 	}
 
 	return facts
+}
+
+// markAbsentPermissionFields records fields the /actions/permissions response
+// should carry but did not — observed when an org or enterprise policy governs
+// the repository (allowed_actions) or on an older GitHub Enterprise Server
+// (sha_pinning_required). Without this the rules reading those fields would
+// emit neither a finding nor a success and vanish from the report; an absent
+// value is unknown, not clean.
+func markAbsentPermissionFields(facts *ActionsSettingsFacts, permissions *github.ActionsPermissionsRepository, repoFull string, dbg DebugLogger) {
+	if permissions.Enabled != nil && !*permissions.Enabled {
+		return
+	}
+	if permissions.AllowedActions == nil {
+		facts.markUndetermined(settingAllowedActions, "GitHub did not report an allowed-actions value for this repository")
+		if dbg != nil {
+			dbg(repoFull, "actions/permissions: allowed_actions absent — undetermined")
+		}
+	}
+	if permissions.SHAPinningRequired == nil {
+		facts.markUndetermined(settingSHAPinning, "GitHub did not report a sha_pinning_required value for this repository")
+		if dbg != nil {
+			dbg(repoFull, "actions/permissions: sha_pinning_required absent — undetermined")
+		}
+	}
 }
 
 // recordSettingsFetchFailure classifies a failed top-level Actions settings
@@ -108,7 +124,7 @@ func (c *factCollector) recordSettingsFetchFailure(facts *ActionsSettingsFacts, 
 		// claim about a setting the scanner never managed to read.
 		cause := describeFetchError(err)
 		c.addWarning("actions settings", cause)
-		for _, setting := range []string{settingAllowedActions, settingWorkflowPermissions, settingForkPRApproval} {
+		for _, setting := range []string{settingAllowedActions, settingWorkflowPermissions, settingForkPRApproval, settingSHAPinning} {
 			facts.markUndetermined(setting, cause)
 		}
 	}

--- a/internal/scanner/settings_test.go
+++ b/internal/scanner/settings_test.go
@@ -349,6 +349,7 @@ func TestCollectActionsSettings_TransientErrorIsNotReportedAsDisabled(t *testing
 		{"default-workflow-permissions", evaluateDefaultWorkflowPermissionsRule, ruleNameDefaultWorkflowPermissions},
 		{"actions-can-approve-prs", evaluateActionsCanApprovePRsRule, ruleNameActionsCanApprovePRs},
 		{"fork-pr-approval", evaluateForkPRContributorApprovalRule, ruleNameForkPRContributorApproval},
+		{"sha-pinning-required", evaluateSHAPinningRequiredRule, ruleNameSHAPinningRequired},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			findings := tc.run(facts)
@@ -546,4 +547,61 @@ func TestApplyRuleConfig_PreservesDeliberateFindingSeverity(t *testing.T) {
 	if got[0].Severity != SeverityLow {
 		t.Fatalf("severity = %q, want the config override to win", got[0].Severity)
 	}
+}
+
+// The SHA-pinning setting rides in the same /actions/permissions response the
+// allowed-actions rule reads, so this rule costs no additional API call — and
+// it has to handle every state that response can be in.
+func TestEvaluateSHAPinningRequiredRule(t *testing.T) {
+	collect := func(t *testing.T, payload map[string]any) *ScanFacts {
+		t.Helper()
+		s, mux := newTestScanner(t, true)
+		handleJSON(mux, "/repos/owner/repo/actions/permissions", payload)
+		handleJSON(mux, "/repos/owner/repo/actions/permissions/workflow", map[string]any{"default_workflow_permissions": "read", "can_approve_pull_request_reviews": false})
+		handleJSON(mux, "/repos/owner/repo/actions/permissions/fork-pr-contributor-approval", map[string]any{"approval_policy": "all_external_contributors"})
+		return &ScanFacts{ActionsSettings: newTestFactCollector(s).collectActionsSettingsFacts(context.Background(), "owner", "repo", nil)}
+	}
+
+	t.Run("not required is a medium finding", func(t *testing.T) {
+		facts := collect(t, map[string]any{"enabled": true, "allowed_actions": "selected", "sha_pinning_required": false})
+		findings := evaluateSHAPinningRequiredRule(facts)
+		if len(findings) != 1 || findings[0].ID != findingIDSHAPinningNotRequired {
+			t.Fatalf("findings = %+v, want one not-required finding", findings)
+		}
+		if findings[0].Severity != SeverityMedium {
+			t.Fatalf("severity = %q, want medium", findings[0].Severity)
+		}
+	})
+
+	t.Run("required passes", func(t *testing.T) {
+		facts := collect(t, map[string]any{"enabled": true, "allowed_actions": "selected", "sha_pinning_required": true})
+		if findings := evaluateSHAPinningRequiredRule(facts); len(findings) != 0 {
+			t.Fatalf("findings = %+v, want none", findings)
+		}
+		if shaPinningRequiredSuccessFinding(ruleNameSHAPinningRequired, SeverityMedium, facts) == nil {
+			t.Fatal("expected a success finding when enforcement is on")
+		}
+	})
+
+	t.Run("absent value is undetermined, not clean", func(t *testing.T) {
+		facts := collect(t, map[string]any{"enabled": true, "allowed_actions": "selected"})
+		findings := evaluateSHAPinningRequiredRule(facts)
+		if len(findings) != 1 || findings[0].Severity != SeverityInfo || findings[0].Success {
+			t.Fatalf("findings = %+v, want one info undetermined finding", findings)
+		}
+		if shaPinningRequiredSuccessFinding(ruleNameSHAPinningRequired, SeverityMedium, facts) != nil {
+			t.Fatal("an unread setting must never be reported as a success")
+		}
+	})
+
+	t.Run("actions observed disabled passes with its own message", func(t *testing.T) {
+		facts := collect(t, map[string]any{"enabled": false})
+		if findings := evaluateSHAPinningRequiredRule(facts); len(findings) != 0 {
+			t.Fatalf("findings = %+v, want none", findings)
+		}
+		success := shaPinningRequiredSuccessFinding(ruleNameSHAPinningRequired, SeverityMedium, facts)
+		if success == nil || !strings.Contains(success.Title, "Actions are disabled") {
+			t.Fatalf("success = %+v, want the disabled pass", success)
+		}
+	})
 }

--- a/testdata/e2e/expected/gasa-fail-private.golden.json
+++ b/testdata/e2e/expected/gasa-fail-private.golden.json
@@ -15,6 +15,12 @@
       "success": true
     },
     {
+      "rule": "actions/permissions/sha-pinning-required",
+      "id": "success-actions-permissions-sha-pinning-required",
+      "severity": "medium",
+      "success": true
+    },
+    {
       "rule": "actions/permissions/workflow/actions-can-approve-prs",
       "id": "success-actions-permissions-workflow-actions-can-approve-prs",
       "severity": "medium",

--- a/testdata/e2e/expected/gasa-fail.golden.json
+++ b/testdata/e2e/expected/gasa-fail.golden.json
@@ -15,6 +15,12 @@
       "success": false
     },
     {
+      "rule": "actions/permissions/sha-pinning-required",
+      "id": "settings-sha-pinning-not-required",
+      "severity": "medium",
+      "success": false
+    },
+    {
       "rule": "actions/permissions/workflow/actions-can-approve-prs",
       "id": "settings-actions-can-approve-prs",
       "severity": "medium",

--- a/testdata/e2e/expected/gasa-pass.golden.json
+++ b/testdata/e2e/expected/gasa-pass.golden.json
@@ -15,6 +15,12 @@
       "success": true
     },
     {
+      "rule": "actions/permissions/sha-pinning-required",
+      "id": "success-actions-permissions-sha-pinning-required",
+      "severity": "medium",
+      "success": true
+    },
+    {
       "rule": "actions/permissions/workflow/actions-can-approve-prs",
       "id": "success-actions-permissions-workflow-actions-can-approve-prs",
       "severity": "medium",

--- a/testdata/e2e/fixtures/gasa-fail-private/repo.yaml
+++ b/testdata/e2e/fixtures/gasa-fail-private/repo.yaml
@@ -5,6 +5,7 @@ private: true
 actions:
     enabled: true
     allowed_actions: selected
+    sha_pinning_required: true
     default_workflow_permissions: read
     can_approve_pull_request_reviews: false
     fork_pr_contributor_approval: n/a

--- a/testdata/e2e/fixtures/gasa-fail/repo.yaml
+++ b/testdata/e2e/fixtures/gasa-fail/repo.yaml
@@ -5,6 +5,7 @@ private: false
 actions:
     enabled: true
     allowed_actions: all
+    sha_pinning_required: false
     default_workflow_permissions: write
     can_approve_pull_request_reviews: true
     fork_pr_contributor_approval: first_time_contributors

--- a/testdata/e2e/fixtures/gasa-pass/repo.yaml
+++ b/testdata/e2e/fixtures/gasa-pass/repo.yaml
@@ -5,6 +5,7 @@ private: false
 actions:
     enabled: true
     allowed_actions: selected
+    sha_pinning_required: true
     default_workflow_permissions: read
     can_approve_pull_request_reviews: false
     fork_pr_contributor_approval: all_external_contributors

--- a/tools/fixtures/main.go
+++ b/tools/fixtures/main.go
@@ -61,6 +61,7 @@ type Manifest struct {
 type Actions struct {
 	Enabled                      *bool  `yaml:"enabled"`
 	AllowedActions               string `yaml:"allowed_actions"`
+	SHAPinningRequired           *bool  `yaml:"sha_pinning_required"`
 	DefaultWorkflowPermissions   string `yaml:"default_workflow_permissions"`
 	CanApprovePullRequestReviews *bool  `yaml:"can_approve_pull_request_reviews"`
 	ForkPRContributorApproval    string `yaml:"fork_pr_contributor_approval"`
@@ -270,6 +271,7 @@ func remoteActions(ctx context.Context, client *github.Client, f fixture) (Actio
 	}
 	got.Enabled = perms.Enabled
 	got.AllowedActions = perms.GetAllowedActions()
+	got.SHAPinningRequired = perms.SHAPinningRequired
 
 	workflow, _, err := client.Repositories.GetDefaultWorkflowPermissions(ctx, owner, name)
 	if err != nil {

--- a/tools/fixtures/modes.go
+++ b/tools/fixtures/modes.go
@@ -82,6 +82,7 @@ func diffActions(repo string, want, got Actions) []string {
 
 	add("enabled", boolText(want.Enabled), boolText(got.Enabled))
 	add("allowed_actions", want.AllowedActions, got.AllowedActions)
+	add("sha_pinning_required", boolText(want.SHAPinningRequired), boolText(got.SHAPinningRequired))
 	add("default_workflow_permissions", want.DefaultWorkflowPermissions, got.DefaultWorkflowPermissions)
 	add("can_approve_pull_request_reviews", boolText(want.CanApprovePullRequestReviews), boolText(got.CanApprovePullRequestReviews))
 	add("fork_pr_contributor_approval", want.ForkPRContributorApproval, got.ForkPRContributorApproval)
@@ -156,18 +157,8 @@ func putFile(ctx context.Context, client *github.Client, owner, name, path, cont
 func applyActions(ctx context.Context, client *github.Client, owner, name string, f fixture) error {
 	a := f.Actions
 
-	if a.Enabled != nil || a.AllowedActions != "" {
-		perms := &github.ActionsPermissionsRepository{}
-		if a.Enabled != nil {
-			perms.Enabled = a.Enabled
-		}
-		if a.AllowedActions != "" {
-			perms.AllowedActions = github.Ptr(a.AllowedActions)
-		}
-		if _, _, err := client.Repositories.UpdateActionsPermissions(ctx, owner, name, *perms); err != nil {
-			return fmt.Errorf("%s: set actions permissions: %w", f.Repo, err)
-		}
-		fmt.Printf("  set allowed_actions=%s\n", a.AllowedActions)
+	if err := applyActionsPermissions(ctx, client, owner, name, f.Repo, a); err != nil {
+		return err
 	}
 
 	if a.DefaultWorkflowPermissions != "" || a.CanApprovePullRequestReviews != nil {
@@ -195,6 +186,27 @@ func applyActions(ctx context.Context, client *github.Client, owner, name string
 		fmt.Printf("  set fork_pr_contributor_approval=%s\n", a.ForkPRContributorApproval)
 	}
 
+	return nil
+}
+
+// applyActionsPermissions writes the top-level Actions permissions (enablement,
+// allowed-actions policy, SHA-pinning enforcement) when the manifest declares
+// any of them.
+func applyActionsPermissions(ctx context.Context, client *github.Client, owner, name, repoFull string, a Actions) error {
+	if a.Enabled == nil && a.AllowedActions == "" && a.SHAPinningRequired == nil {
+		return nil
+	}
+	perms := github.ActionsPermissionsRepository{
+		Enabled:            a.Enabled,
+		SHAPinningRequired: a.SHAPinningRequired,
+	}
+	if a.AllowedActions != "" {
+		perms.AllowedActions = github.Ptr(a.AllowedActions)
+	}
+	if _, _, err := client.Repositories.UpdateActionsPermissions(ctx, owner, name, perms); err != nil {
+		return fmt.Errorf("%s: set actions permissions: %w", repoFull, err)
+	}
+	fmt.Printf("  set allowed_actions=%s sha_pinning_required=%s\n", a.AllowedActions, boolText(a.SHAPinningRequired))
 	return nil
 }
 


### PR DESCRIPTION
**Stack #61, layer 5 of 9.**

GitHub's "Require actions to be pinned to a full-length commit SHA" setting rides in the same `GET /actions/permissions` response the allowed-actions rule already parses — the scanner was ignoring it. New rule `actions/permissions/sha-pinning-required` (medium) reads it at **zero additional API cost**.

Complements `action-version-pinning` precisely: that rule proves the files are pinned *today*; this setting stops an unpinned ref ever running *tomorrow* (GitHub refuses to run workflows referencing mutable tags while enforcement is on). The remediation says pin files first — flipping the setting on an unpinned repo blocks its workflows.

**Never-silent, all four states covered by tests:**
| state | result |
|---|---|
| `false` | medium finding |
| `true` | pass |
| Actions observed disabled | pass with its own message |
| field absent (older GHES) | informational *undetermined* finding |

A transient settings failure marks it undetermined alongside the other four settings rules.

Fixture states **already applied live** (settings changes are invisible to main's older scanner/manifests): enforcement ON for gasa-pass and gasa-fail-private — all their workflows are SHA-pinned, so nothing breaks — OFF for gasa-fail. The fixtures tool now declares/captures/verifies/applies the setting, and `fixtures-verify` shows zero settings drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN
