### PR TITLE
Downgrade pull-request-target severity where external PRs cannot exist (R16)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1431,10 +1431,10 @@ Candidates, in rough order of value:
    concerns. It is not rule coupling: the policy is a *fact* (read from the same `GET /repos` response
    the scan always made, decoded via a wrapper struct because go-github v84 does not model the field),
    and rules consuming facts is exactly what the fact model is for. The finding stays critical by
-   default and drops to high — never lower — when the repository is private or its policy is
+   default and drops to medium — never lower — when the repository is private or its policy is
    `collaborators_only`, the one value proven to block external PR creation. Unknown or new policy
    values keep the critical reading, so GitHub adding an enum value can only over-report. `gasa-fail`
-   is exactly this case (public + `collaborators_only`), so its golden finding moves critical → high,
+   is exactly this case (public + `collaborators_only`), so its golden finding moves critical → medium,
    which is more accurate: that mitigation is real and the audit verified it live
 
 Implementation requirements for any of these:

--- a/PLAN.md
+++ b/PLAN.md
@@ -1426,13 +1426,16 @@ Candidates, in rough order of value:
    nothing breaks), OFF for `gasa-fail`. The fixtures tool now declares, verifies, and applies the
    setting
 
-3. **`pull_request_creation_policy` (from R16).** Present on the repository object the scanner already
-   fetches. `gasa-fail` reports `collaborators_only`, `gasa-pass` reports `all`. It is the control that
-   determines whether external contributors can open pull requests at all, making it the single setting
-   that most directly neutralizes `pull_request_target` risk on a public repo. Two designs: a
-   standalone rule, or context that modulates the `pull-request-target` rule's severity. The second is
-   more useful but couples two rules, which the rule engine does not currently support and Phase 7 has
-   not designed for
+3. ~~**`pull_request_creation_policy` (from R16).**~~ **Done 2026-08-12** as severity modulation
+   inside the `pull-request-target` rule — the design PLAN preferred but deferred over rule-coupling
+   concerns. It is not rule coupling: the policy is a *fact* (read from the same `GET /repos` response
+   the scan always made, decoded via a wrapper struct because go-github v84 does not model the field),
+   and rules consuming facts is exactly what the fact model is for. The finding stays critical by
+   default and drops to high — never lower — when the repository is private or its policy is
+   `collaborators_only`, the one value proven to block external PR creation. Unknown or new policy
+   values keep the critical reading, so GitHub adding an enum value can only over-report. `gasa-fail`
+   is exactly this case (public + `collaborators_only`), so its golden finding moves critical → high,
+   which is more accurate: that mitigation is real and the audit verified it live
 
 Implementation requirements for any of these:
 

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ The scanner runs the following checks against each repository. Findings are rate
 
 | Check | Category | Severity | What it fixes |
 |-------|----------|----------|-----------------|
-| [Pull Request Target](docs/rules/pull-request-target.md) | Workflows | Critical | `pull_request_target`, which should never be used in a public repo and is highly discouraged in a private repo |
+| [Pull Request Target](docs/rules/pull-request-target.md) | Workflows | Critical | `pull_request_target`, which should never be used in a public repo; the finding drops to high (never lower) when external contributors cannot open PRs at all |
 | [Action Version Pinning](docs/rules/action-version-pinning.md) | Workflows | High | Actions referenced by tag (`@v4`) or branch (`@main`) instead of commit SHA |
 | [Workflow Permissions](docs/rules/workflow-permissions.md) | Workflows | High | Workflows without an explicit `permissions` block, inheriting overly broad defaults |
 | [Write-All Workflow Permissions](docs/rules/write-all-permissions.md) | Workflows | High | Workflows granting `write-all`, the broadest possible `GITHUB_TOKEN` grant |

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ The scanner runs the following checks against each repository. Findings are rate
 
 | Check | Category | Severity | What it fixes |
 |-------|----------|----------|-----------------|
-| [Pull Request Target](docs/rules/pull-request-target.md) | Workflows | Critical | `pull_request_target`, which should never be used in a public repo; the finding drops to high (never lower) when external contributors cannot open PRs at all |
+| [Pull Request Target](docs/rules/pull-request-target.md) | Workflows | Critical | `pull_request_target`, which should never be used in a public repo; the finding drops to medium (never lower) when external contributors cannot open PRs at all |
 | [Action Version Pinning](docs/rules/action-version-pinning.md) | Workflows | High | Actions referenced by tag (`@v4`) or branch (`@main`) instead of commit SHA |
 | [Workflow Permissions](docs/rules/workflow-permissions.md) | Workflows | High | Workflows without an explicit `permissions` block, inheriting overly broad defaults |
 | [Write-All Workflow Permissions](docs/rules/write-all-permissions.md) | Workflows | High | Workflows granting `write-all`, the broadest possible `GITHUB_TOKEN` grant |

--- a/docs/rules/pull-request-target.md
+++ b/docs/rules/pull-request-target.md
@@ -27,7 +27,7 @@ messages:
       repository (it is private, or its pull request creation policy is limited
       to collaborators), so there is no untrusted pull request for the workflow
       to act on today — but that mitigation is a repository setting, one click
-      away from disappearing, which is why this is high rather than resolved.
+      away from disappearing, which is why this is medium rather than resolved.
     fix: >-
       Use the `pull_request` event instead. If you cannot avoid
       `pull_request_target`, keep the workflow limited to trusted base-branch
@@ -69,7 +69,7 @@ This rule does not try to prove whether the workflow later checks out untrusted 
 
 ### Severity
 
-The finding is **critical** by default. It drops to **high** — never lower — when external
+The finding is **critical** by default. It drops to **medium** — never lower — when external
 contributors cannot open pull requests against the repository at all: the repository is private, or
 its `pull_request_creation_policy` is `collaborators_only`. In that state there is no untrusted
 pull request for the workflow to act on, but the protection is a repository setting rather than a

--- a/docs/rules/pull-request-target.md
+++ b/docs/rules/pull-request-target.md
@@ -18,6 +18,20 @@ messages:
       Use the `pull_request` event instead. If you cannot avoid
       `pull_request_target`, keep the workflow limited to trusted base-branch
       code only and never check out or execute untrusted pull request code.
+  used-restricted:
+    title: pull_request_target event is used (external PRs are restricted)
+    description: >-
+      This workflow uses `pull_request_target`, which runs in the context of the
+      base branch with access to a more trusted token and potentially secrets.
+      External contributors cannot currently open pull requests against this
+      repository (it is private, or its pull request creation policy is limited
+      to collaborators), so there is no untrusted pull request for the workflow
+      to act on today — but that mitigation is a repository setting, one click
+      away from disappearing, which is why this is high rather than resolved.
+    fix: >-
+      Use the `pull_request` event instead. If you cannot avoid
+      `pull_request_target`, keep the workflow limited to trusted base-branch
+      code only and never check out or execute untrusted pull request code.
   pass:
     title: pull_request_target event is not used
     description: >-
@@ -52,6 +66,18 @@ The scanner:
   - a mapping with a `pull_request_target` key
 
 This rule does not try to prove whether the workflow later checks out untrusted code. It flags any use of `pull_request_target` because that event should never be used in a public repository and is highly discouraged in a private repository.
+
+### Severity
+
+The finding is **critical** by default. It drops to **high** — never lower — when external
+contributors cannot open pull requests against the repository at all: the repository is private, or
+its `pull_request_creation_policy` is `collaborators_only`. In that state there is no untrusted
+pull request for the workflow to act on, but the protection is a repository setting rather than a
+property of the workflow, so the dangerous pattern still warrants a finding. Only that one
+known-restricted policy value downgrades; an unknown or absent value keeps the critical reading,
+so a new GitHub policy value can only over-report, never under-report. The policy is read from the
+same `GET /repos/{owner}/{repo}` response the scan always made, so this costs no additional API
+call.
 
 ## Why this matters
 

--- a/internal/scanner/facts.go
+++ b/internal/scanner/facts.go
@@ -17,9 +17,14 @@ func (c *factCollector) addWarning(area, detail string) {
 }
 
 type ScanFacts struct {
-	Repository                              *github.Repository
-	RepositoryOwner                         string
-	DefaultBranch                           string
+	Repository      *github.Repository
+	RepositoryOwner string
+	DefaultBranch   string
+	// PullRequestCreationPolicy is the repository setting controlling who may
+	// open pull requests ("all", "collaborators_only", …). Carried separately
+	// from Repository because go-github does not model the field. Empty when
+	// GitHub did not report it.
+	PullRequestCreationPolicy               string
 	Workflows                               []WorkflowFact
 	ActionsSettings                         ActionsSettingsFacts
 	Dependabot                              DependabotFacts
@@ -128,10 +133,11 @@ type factCollector struct {
 	warnings []FactWarning
 }
 
-func (c *factCollector) collectFacts(ctx context.Context, owner, repo string, repository *github.Repository, cfg *Config, dbg DebugLogger) *ScanFacts {
+func (c *factCollector) collectFacts(ctx context.Context, owner, repo string, repository *github.Repository, prCreationPolicy string, cfg *Config, dbg DebugLogger) *ScanFacts {
 	facts := &ScanFacts{
 		Repository:                              repository,
 		RepositoryOwner:                         owner,
+		PullRequestCreationPolicy:               prCreationPolicy,
 		DefaultBranch:                           "HEAD",
 		ActionVersionPinningIgnoreSameOwner:     cfg.actionVersionPinningIgnoreSameOwner(),
 		UpdateToolConfigurationRequireWorkflows: cfg.updateToolConfigurationRequireWorkflows(),

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -620,12 +620,12 @@ func externalPRCreationRestricted(facts *ScanFacts) bool {
 func evaluateDangerousWorkflowRule(facts *ScanFacts) []Finding {
 	// The trigger is the same, but the blast radius is not: where external
 	// contributors cannot open PRs at all, there is no untrusted head for the
-	// workflow to check out today. High instead of critical — the mitigation is
-	// a repository setting, one click away from disappearing, so it never
+	// workflow to check out today. Medium instead of critical — the mitigation
+	// is a repository setting, one click away from disappearing, so it never
 	// downgrades further than that.
 	severity, msgKey := SeverityCritical, "used"
 	if externalPRCreationRestricted(facts) {
-		severity, msgKey = SeverityHigh, "used-restricted"
+		severity, msgKey = SeverityMedium, "used-restricted"
 	}
 
 	var findings []Finding

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -598,16 +598,45 @@ func actionsObservedDisabled(facts *ScanFacts) bool {
 	return permissions != nil && permissions.Enabled != nil && !*permissions.Enabled
 }
 
+// prCreationPolicyCollaboratorsOnly is the one pull_request_creation_policy
+// value known to prevent external contributors from opening pull requests at
+// all. Only this known-restricted value downgrades the finding; an unknown or
+// absent value keeps the severe reading, so a new GitHub enum value can only
+// over-report, never under-report.
+const prCreationPolicyCollaboratorsOnly = "collaborators_only"
+
+// externalPRCreationRestricted reports whether external contributors are unable
+// to open pull requests against this repository — private repositories take
+// only collaborator PRs by nature, and the creation policy can restrict public
+// ones the same way. When true there is no untrusted pull request for a
+// pull_request_target workflow to act on today.
+func externalPRCreationRestricted(facts *ScanFacts) bool {
+	if facts.Repository.GetPrivate() {
+		return true
+	}
+	return facts.PullRequestCreationPolicy == prCreationPolicyCollaboratorsOnly
+}
+
 func evaluateDangerousWorkflowRule(facts *ScanFacts) []Finding {
+	// The trigger is the same, but the blast radius is not: where external
+	// contributors cannot open PRs at all, there is no untrusted head for the
+	// workflow to check out today. High instead of critical — the mitigation is
+	// a repository setting, one click away from disappearing, so it never
+	// downgrades further than that.
+	severity, msgKey := SeverityCritical, "used"
+	if externalPRCreationRestricted(facts) {
+		severity, msgKey = SeverityHigh, "used-restricted"
+	}
+
 	var findings []Finding
 	for _, wf := range facts.Workflows {
 		if !wf.Valid || !hasDangerousTrigger(wf.Workflow.On) {
 			continue
 		}
-		msg := ruleMessage(ruleNamePullRequestTarget, "used", nil)
+		msg := ruleMessage(ruleNamePullRequestTarget, msgKey, nil)
 		findings = append(findings, Finding{
 			ID:          fmt.Sprintf("dangerous-trigger-%s", wf.Path),
-			Severity:    SeverityCritical,
+			Severity:    severity,
 			Title:       msg.Title,
 			Description: msg.Description,
 			File:        wf.Path,

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -122,6 +122,31 @@ func (s *Scanner) GitHubClient() *github.Client {
 	return s.client
 }
 
+// repositoryWithPolicy captures pull_request_creation_policy, which go-github
+// v84 does not model on Repository. The embedded struct keeps every field the
+// rest of the scanner reads; JSON unmarshalling promotes into it, and
+// Repository has no custom UnmarshalJSON to hijack that.
+type repositoryWithPolicy struct {
+	github.Repository
+	PullRequestCreationPolicy string `json:"pull_request_creation_policy"`
+}
+
+// fetchRepository performs the same GET /repos/{owner}/{repo} the scan always
+// made, decoding one extra field. One request, not two: duplicating the call
+// just to read a single field would spend exactly the budget the file
+// inventory work exists to save.
+func fetchRepository(ctx context.Context, client *github.Client, owner, repo string) (*github.Repository, string, error) {
+	req, err := client.NewRequest("GET", fmt.Sprintf("repos/%v/%v", owner, repo), nil)
+	if err != nil {
+		return nil, "", err
+	}
+	var wrapped repositoryWithPolicy
+	if _, err := client.Do(ctx, req, &wrapped); err != nil {
+		return nil, "", err
+	}
+	return &wrapped.Repository, wrapped.PullRequestCreationPolicy, nil
+}
+
 // ScanRepo performs all security checks on a repository.
 func (s *Scanner) ScanRepo(ctx context.Context, owner, repo string) (*ScanResult, error) {
 	return s.ScanRepoWithOptions(ctx, owner, repo, ScanOptions{})
@@ -142,7 +167,7 @@ func (s *Scanner) ScanRepoWithOptions(ctx context.Context, owner, repo string, o
 	if dbg != nil {
 		dbg(repoFull, "GET /repos/"+repoFull)
 	}
-	repository, _, err := s.client.Repositories.Get(ctx, owner, repo)
+	repository, prCreationPolicy, err := fetchRepository(ctx, s.client, owner, repo)
 	if err != nil {
 		result.Error = classifyGitHubRepoAccessError(err)
 		if dbg != nil {
@@ -155,7 +180,7 @@ func (s *Scanner) ScanRepoWithOptions(ctx context.Context, owner, repo string, o
 	}
 
 	collector := &factCollector{client: s.client, authenticated: s.authenticated}
-	facts := collector.collectFacts(ctx, owner, repo, repository, opts.Config, dbg)
+	facts := collector.collectFacts(ctx, owner, repo, repository, prCreationPolicy, opts.Config, dbg)
 
 	// Surface any checks that could not be completed so a partial scan is never
 	// mistaken for a clean one.

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -395,3 +395,47 @@ func TestEvaluateWriteAllPermissionsRule(t *testing.T) {
 		}
 	})
 }
+
+// pull_request_target's blast radius depends on whether an external contributor
+// can open a PR at all. The severity must track that — and must fail severe
+// when the policy is unknown, so a new GitHub enum value can only over-report.
+func TestEvaluateDangerousWorkflowRule_SeverityTracksPRCreationPolicy(t *testing.T) {
+	prtWorkflow := func(t *testing.T) []WorkflowFact {
+		t.Helper()
+		content := "on: pull_request_target\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n"
+		workflow := &WorkflowFile{}
+		if err := yaml.Unmarshal([]byte(content), workflow); err != nil {
+			t.Fatalf("yaml.Unmarshal() error: %v", err)
+		}
+		return []WorkflowFact{{Path: ".github/workflows/prt.yml", Content: content, Workflow: workflow, Valid: true}}
+	}
+
+	cases := []struct {
+		name         string
+		facts        *ScanFacts
+		wantSeverity string
+		wantRestrict bool
+	}{
+		{"public, policy all", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false)}, PullRequestCreationPolicy: "all"}, SeverityCritical, false},
+		{"public, policy unknown stays critical", &ScanFacts{Repository: &github.Repository{}}, SeverityCritical, false},
+		{"public, collaborators only", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false)}, PullRequestCreationPolicy: "collaborators_only"}, SeverityHigh, true},
+		{"private repository", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(true)}, PullRequestCreationPolicy: "all"}, SeverityHigh, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.facts.Workflows = prtWorkflow(t)
+			findings := evaluateDangerousWorkflowRule(tc.facts)
+			if len(findings) != 1 {
+				t.Fatalf("findings = %+v, want one", findings)
+			}
+			if findings[0].Severity != tc.wantSeverity {
+				t.Fatalf("severity = %q, want %q", findings[0].Severity, tc.wantSeverity)
+			}
+			restricted := strings.Contains(findings[0].Title, "restricted")
+			if restricted != tc.wantRestrict {
+				t.Fatalf("title = %q, restricted-variant = %v, want %v", findings[0].Title, restricted, tc.wantRestrict)
+			}
+		})
+	}
+}

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -418,8 +418,8 @@ func TestEvaluateDangerousWorkflowRule_SeverityTracksPRCreationPolicy(t *testing
 	}{
 		{"public, policy all", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false)}, PullRequestCreationPolicy: "all"}, SeverityCritical, false},
 		{"public, policy unknown stays critical", &ScanFacts{Repository: &github.Repository{}}, SeverityCritical, false},
-		{"public, collaborators only", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false)}, PullRequestCreationPolicy: "collaborators_only"}, SeverityHigh, true},
-		{"private repository", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(true)}, PullRequestCreationPolicy: "all"}, SeverityHigh, true},
+		{"public, collaborators only", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false)}, PullRequestCreationPolicy: "collaborators_only"}, SeverityMedium, true},
+		{"private repository", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(true)}, PullRequestCreationPolicy: "all"}, SeverityMedium, true},
 	}
 
 	for _, tc := range cases {

--- a/testdata/e2e/expected/gasa-fail.golden.json
+++ b/testdata/e2e/expected/gasa-fail.golden.json
@@ -89,7 +89,7 @@
     {
       "rule": "workflows/pull-request-target",
       "id": "dangerous-trigger-.github/workflows/bad-pull-request-target.yaml",
-      "severity": "critical",
+      "severity": "high",
       "success": false
     },
     {

--- a/testdata/e2e/expected/gasa-fail.golden.json
+++ b/testdata/e2e/expected/gasa-fail.golden.json
@@ -89,7 +89,7 @@
     {
       "rule": "workflows/pull-request-target",
       "id": "dangerous-trigger-.github/workflows/bad-pull-request-target.yaml",
-      "severity": "high",
+      "severity": "medium",
       "success": false
     },
     {


### PR DESCRIPTION
**Stack #61, layer 6 of 9.** Severity values in this layer are superseded by the full matrix in #63; merge target for the stack is now #64.

A public repo running `pull_request_target` with `pull_request_creation_policy: collaborators_only` has **no untrusted pull request for the workflow to act on** — the exact mitigation the fixture audit verified live on gasa-fail — yet the scanner reported it identically to a fully exposed repo.

**The design decision to review:** PLAN deferred this as "severity modulation couples two rules." Implemented, it isn't rule coupling — the policy is a *fact*, read from the same `GET /repos/{owner}/{repo}` response the scan always made, and rules consuming facts is what the fact model is for. go-github v84 doesn't model the field, so the fetch decodes into a wrapper struct with `Repository` embedded: **one request, unchanged, one extra field**.

Behavior:
- critical by default
- drops to **medium, never lower**, when the repo is private or policy is `collaborators_only`
- unknown/absent/future policy values keep critical — a new GitHub enum value can only **over-report**
- the restricted variant gets its own title/description so the operator knows why

Golden diff is exactly one line: gasa-fail's dangerous-trigger finding `critical → medium`. That's more accurate reporting — the audit confirmed that repo genuinely cannot receive external PRs.

## Merging this stack

1. Review each PR; mark ready (`gh pr ready 55` … `60`)
2. `gh stack merge 64 --yes --squash` — **not** `gh pr merge`, which mis-targets stacked PRs
3. Fixtures are already applied live, so main's e2e goes green on merge; until then the nightly reports drift by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN
