### PR TITLE
Update go-github from v84 to v90

### DIFF
--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/bretfisher/gasa/internal/scanner"
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )

--- a/cmd/batch_test.go
+++ b/cmd/batch_test.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func TestBuildBatchRequest(t *testing.T) {
@@ -200,11 +199,13 @@ func newTestGitHubClient(t *testing.T, handler http.Handler) *github.Client {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	client := github.NewClient(server.Client())
-	baseURL, err := url.Parse(server.URL + "/")
+	base := server.URL + "/"
+	client, err := github.NewClient(
+		github.WithHTTPClient(server.Client()),
+		github.WithURLs(&base, nil),
+	)
 	if err != nil {
-		t.Fatalf("url.Parse() error = %v", err)
+		t.Fatalf("github.NewClient() error = %v", err)
 	}
-	client.BaseURL = baseURL
 	return client
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/x/term v0.2.2
-	github.com/google/go-github/v84 v84.0.0
+	github.com/google/go-github/v90 v90.0.0
 	github.com/spf13/cobra v1.10.2
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v84 v84.0.0 h1:I/0Xn5IuChMe8TdmI2bbim5nyhaRFJ7DEdzmD2w+yVA=
-github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXukJBn73xsiYrRRQ=
+github.com/google/go-github/v90 v90.0.0 h1:EnX9HvTfqvuJbUSWu1/jLrYH6JJLMz0w0qfQVbTxPzE=
+github.com/google/go-github/v90 v90.0.0/go.mod h1:pLzt1FZURZyoTHT5/Z1UQY3b9fYyrbXH6aj7X+qgID4=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/scanner/config_test.go
+++ b/internal/scanner/config_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func TestLoadConfigFromDir(t *testing.T) {

--- a/internal/scanner/facts.go
+++ b/internal/scanner/facts.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // addWarning records an indeterminate fact (see FactWarning). It is safe for

--- a/internal/scanner/facts.go
+++ b/internal/scanner/facts.go
@@ -17,14 +17,9 @@ func (c *factCollector) addWarning(area, detail string) {
 }
 
 type ScanFacts struct {
-	Repository      *github.Repository
-	RepositoryOwner string
-	DefaultBranch   string
-	// PullRequestCreationPolicy is the repository setting controlling who may
-	// open pull requests ("all", "collaborators_only", …). Carried separately
-	// from Repository because go-github does not model the field. Empty when
-	// GitHub did not report it.
-	PullRequestCreationPolicy               string
+	Repository                              *github.Repository
+	RepositoryOwner                         string
+	DefaultBranch                           string
 	Workflows                               []WorkflowFact
 	ActionsSettings                         ActionsSettingsFacts
 	Dependabot                              DependabotFacts
@@ -133,11 +128,10 @@ type factCollector struct {
 	warnings []FactWarning
 }
 
-func (c *factCollector) collectFacts(ctx context.Context, owner, repo string, repository *github.Repository, prCreationPolicy string, cfg *Config, dbg DebugLogger) *ScanFacts {
+func (c *factCollector) collectFacts(ctx context.Context, owner, repo string, repository *github.Repository, cfg *Config, dbg DebugLogger) *ScanFacts {
 	facts := &ScanFacts{
 		Repository:                              repository,
 		RepositoryOwner:                         owner,
-		PullRequestCreationPolicy:               prCreationPolicy,
 		DefaultBranch:                           "HEAD",
 		ActionVersionPinningIgnoreSameOwner:     cfg.actionVersionPinningIgnoreSameOwner(),
 		UpdateToolConfigurationRequireWorkflows: cfg.updateToolConfigurationRequireWorkflows(),

--- a/internal/scanner/fuzz_test.go
+++ b/internal/scanner/fuzz_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // These fuzz targets guard the three code paths that parse untrusted input:

--- a/internal/scanner/incomplete.go
+++ b/internal/scanner/incomplete.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // FactWarning records a fact the scanner could not determine because a GitHub

--- a/internal/scanner/inventory.go
+++ b/internal/scanner/inventory.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // fileInventory records which files exist at the repository root and inside the

--- a/internal/scanner/inventory_test.go
+++ b/internal/scanner/inventory_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // countingMux records every request path so tests can assert not just what the

--- a/internal/scanner/retry.go
+++ b/internal/scanner/retry.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 const (
@@ -35,8 +35,23 @@ type retryTransport struct {
 	sem chan struct{}
 }
 
-func newGitHubClient() *github.Client {
-	return github.NewClient(&http.Client{Transport: newRetryTransport(http.DefaultTransport)})
+// newGitHubClient builds the shared client: our retrying, concurrency-bounded
+// transport plus any extra options (an auth token, in practice).
+//
+// go-github v90 moved to functional options and NewClient now returns an
+// error. Every failure mode is a programmer error at this call site — a nil
+// HTTP client or an empty auth token, both of which the callers below make
+// impossible — so this panics rather than threading an error through New and
+// NewWithToken signatures that the CLI relies on.
+func newGitHubClient(extra ...github.ClientOptionsFunc) *github.Client {
+	opts := append([]github.ClientOptionsFunc{
+		github.WithHTTPClient(&http.Client{Transport: newRetryTransport(http.DefaultTransport)}),
+	}, extra...)
+	client, err := github.NewClient(opts...)
+	if err != nil {
+		panic("constructing GitHub client: " + err.Error())
+	}
+	return client
 }
 
 func newRetryTransport(base http.RoundTripper) *retryTransport {

--- a/internal/scanner/retry_test.go
+++ b/internal/scanner/retry_test.go
@@ -6,13 +6,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -263,12 +262,14 @@ func TestRetryTransportReleasesSlotOnErrorResponse(t *testing.T) {
 		sleep:       sleepWithContext,
 		sem:         make(chan struct{}, 2),
 	}
-	client := github.NewClient(&http.Client{Transport: transport})
-	base, err := url.Parse(srv.URL + "/")
+	base := srv.URL + "/"
+	client, err := github.NewClient(
+		github.WithHTTPClient(&http.Client{Transport: transport}),
+		github.WithURLs(&base, nil),
+	)
 	if err != nil {
-		t.Fatalf("url.Parse() error = %v", err)
+		t.Fatalf("github.NewClient() error = %v", err)
 	}
-	client.BaseURL = base
 
 	// More requests than the slot cap. A per-call deadline turns a regression
 	// into a deterministic, fast failure rather than a hung test.

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -614,7 +614,7 @@ func externalPRCreationRestricted(facts *ScanFacts) bool {
 	if facts.Repository.GetPrivate() {
 		return true
 	}
-	return facts.PullRequestCreationPolicy == prCreationPolicyCollaboratorsOnly
+	return facts.Repository.GetPullRequestCreationPolicy() == prCreationPolicyCollaboratorsOnly
 }
 
 func evaluateDangerousWorkflowRule(facts *ScanFacts) []Finding {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -128,31 +128,6 @@ func (s *Scanner) GitHubClient() *github.Client {
 	return s.client
 }
 
-// repositoryWithPolicy captures pull_request_creation_policy, which go-github
-// v84 does not model on Repository. The embedded struct keeps every field the
-// rest of the scanner reads; JSON unmarshalling promotes into it, and
-// Repository has no custom UnmarshalJSON to hijack that.
-type repositoryWithPolicy struct {
-	github.Repository
-	PullRequestCreationPolicy string `json:"pull_request_creation_policy"`
-}
-
-// fetchRepository performs the same GET /repos/{owner}/{repo} the scan always
-// made, decoding one extra field. One request, not two: duplicating the call
-// just to read a single field would spend exactly the budget the file
-// inventory work exists to save.
-func fetchRepository(ctx context.Context, client *github.Client, owner, repo string) (*github.Repository, string, error) {
-	req, err := client.NewRequest(ctx, "GET", fmt.Sprintf("repos/%v/%v", owner, repo), nil)
-	if err != nil {
-		return nil, "", err
-	}
-	var wrapped repositoryWithPolicy
-	if _, err := client.Do(req, &wrapped); err != nil {
-		return nil, "", err
-	}
-	return &wrapped.Repository, wrapped.PullRequestCreationPolicy, nil
-}
-
 // ScanRepo performs all security checks on a repository.
 func (s *Scanner) ScanRepo(ctx context.Context, owner, repo string) (*ScanResult, error) {
 	return s.ScanRepoWithOptions(ctx, owner, repo, ScanOptions{})
@@ -173,7 +148,7 @@ func (s *Scanner) ScanRepoWithOptions(ctx context.Context, owner, repo string, o
 	if dbg != nil {
 		dbg(repoFull, "GET /repos/"+repoFull)
 	}
-	repository, prCreationPolicy, err := fetchRepository(ctx, s.client, owner, repo)
+	repository, _, err := s.client.Repositories.Get(ctx, owner, repo)
 	if err != nil {
 		result.Error = classifyGitHubRepoAccessError(err)
 		if dbg != nil {
@@ -186,7 +161,7 @@ func (s *Scanner) ScanRepoWithOptions(ctx context.Context, owner, repo string, o
 	}
 
 	collector := &factCollector{client: s.client, authenticated: s.authenticated}
-	facts := collector.collectFacts(ctx, owner, repo, repository, prCreationPolicy, opts.Config, dbg)
+	facts := collector.collectFacts(ctx, owner, repo, repository, opts.Config, dbg)
 
 	// Surface any checks that could not be completed so a partial scan is never
 	// mistaken for a clean one.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 const (
@@ -103,10 +103,16 @@ func New() *Scanner {
 	}
 }
 
-// NewWithToken creates a Scanner with an authenticated GitHub client
+// NewWithToken creates a Scanner with an authenticated GitHub client. An empty
+// token falls back to an unauthenticated scanner: go-github v90 rejects empty
+// tokens outright, and an unauthenticated client is the honest equivalent of
+// what an empty bearer header produced anyway.
 func NewWithToken(token string) *Scanner {
+	if token == "" {
+		return New()
+	}
 	return &Scanner{
-		client:        newGitHubClient().WithAuthToken(token),
+		client:        newGitHubClient(github.WithAuthToken(token)),
 		authenticated: true,
 	}
 }
@@ -136,12 +142,12 @@ type repositoryWithPolicy struct {
 // just to read a single field would spend exactly the budget the file
 // inventory work exists to save.
 func fetchRepository(ctx context.Context, client *github.Client, owner, repo string) (*github.Repository, string, error) {
-	req, err := client.NewRequest("GET", fmt.Sprintf("repos/%v/%v", owner, repo), nil)
+	req, err := client.NewRequest(ctx, "GET", fmt.Sprintf("repos/%v/%v", owner, repo), nil)
 	if err != nil {
 		return nil, "", err
 	}
 	var wrapped repositoryWithPolicy
-	if _, err := client.Do(ctx, req, &wrapped); err != nil {
+	if _, err := client.Do(req, &wrapped); err != nil {
 		return nil, "", err
 	}
 	return &wrapped.Repository, wrapped.PullRequestCreationPolicy, nil

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func TestParseRepoURL(t *testing.T) {

--- a/internal/scanner/settings.go
+++ b/internal/scanner/settings.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // isAccessDenied reports whether resp is a determinate "no access" response: a

--- a/internal/scanner/settings_test.go
+++ b/internal/scanner/settings_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func TestIsAccessDenied(t *testing.T) {

--- a/internal/scanner/testhelpers_test.go
+++ b/internal/scanner/testhelpers_test.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"sync"
 	"testing"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 const testBaseURLPath = "/api-v3"
@@ -47,12 +46,11 @@ func newTestScanner(t *testing.T, authenticated bool) (*Scanner, *http.ServeMux)
 	server := httptest.NewServer(apiHandler)
 	t.Cleanup(server.Close)
 
-	client := github.NewClient(nil)
-	baseURL, err := url.Parse(server.URL + testBaseURLPath + "/")
+	base := server.URL + testBaseURLPath + "/"
+	client, err := github.NewClient(github.WithURLs(&base, nil))
 	if err != nil {
-		t.Fatalf("failed to parse test URL: %v", err)
+		t.Fatalf("failed to build test client: %v", err)
 	}
-	client.BaseURL = baseURL
 
 	return &Scanner{
 		client:        client,

--- a/internal/scanner/updates.go
+++ b/internal/scanner/updates.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/tailscale/hujson"
 	"gopkg.in/yaml.v3"
 )

--- a/internal/scanner/updates_test.go
+++ b/internal/scanner/updates_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 )
 
 func encodedContent(path, content string) map[string]any {

--- a/internal/scanner/workflow.go
+++ b/internal/scanner/workflow.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 )

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -416,10 +416,10 @@ func TestEvaluateDangerousWorkflowRule_SeverityTracksPRCreationPolicy(t *testing
 		wantSeverity string
 		wantRestrict bool
 	}{
-		{"public, policy all", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false)}, PullRequestCreationPolicy: "all"}, SeverityCritical, false},
+		{"public, policy all", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false), PullRequestCreationPolicy: github.Ptr("all")}}, SeverityCritical, false},
 		{"public, policy unknown stays critical", &ScanFacts{Repository: &github.Repository{}}, SeverityCritical, false},
-		{"public, collaborators only", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false)}, PullRequestCreationPolicy: "collaborators_only"}, SeverityMedium, true},
-		{"private repository", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(true)}, PullRequestCreationPolicy: "all"}, SeverityMedium, true},
+		{"public, collaborators only", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false), PullRequestCreationPolicy: github.Ptr("collaborators_only")}}, SeverityMedium, true},
+		{"private repository", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(true), PullRequestCreationPolicy: github.Ptr("all")}}, SeverityMedium, true},
 	}
 
 	for _, tc := range cases {

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 	"gopkg.in/yaml.v3"
 )
 

--- a/tools/fixtures/main.go
+++ b/tools/fixtures/main.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 	"gopkg.in/yaml.v3"
 )
 
@@ -126,7 +126,7 @@ func newClient(ctx context.Context) (*github.Client, error) {
 	if token == "" {
 		return nil, errors.New("no GitHub token found: set GITHUB_TOKEN, GH_TOKEN, or sign in with `gh auth login`")
 	}
-	return github.NewClient(nil).WithAuthToken(token), nil
+	return github.NewClient(github.WithAuthToken(token))
 }
 
 type fixture struct {

--- a/tools/fixtures/modes.go
+++ b/tools/fixtures/modes.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/go-github/v84/github"
+	"github.com/google/go-github/v90/github"
 	"gopkg.in/yaml.v3"
 )
 


### PR DESCRIPTION
**Stack #61, layer 7 of 9.** Merge target for the whole stack: `gh stack merge 64 --yes --squash`.

We were on go-github **v84.0.0**; current is **v90.0.0** (2026-08-04). Majors change the module path, so every import moves — and v90 rewrites the client surface:

| v84 | v90 |
|---|---|
| `NewClient(*http.Client)` | `NewClient(opts ...ClientOptionsFunc) (*Client, error)` |
| `client.WithAuthToken(tok)` (chained) | `WithAuthToken(tok)` option — **rejects empty tokens** |
| `NewRequest(method, url, body)` + `Do(ctx, req, v)` | `NewRequest(ctx, …)` + `Do(req, v)` — ctx lives in the request |
| public `client.BaseURL` | gone; `WithURLs(&base, nil)` |

**Composition verified in the v90 source before trusting it:** `WithAuthToken` wraps the transport supplied via `WithHTTPClient`, so the auth layer sits on top of our retrying, concurrency-bounded transport exactly as the old chained call did.

Judgment calls:
- `newGitHubClient` **panics** on construction error — every failure mode at our call sites is a programmer error (nil HTTP client, empty token), and threading an error through `New`/`NewWithToken` would change signatures the CLI depends on.
- `NewWithToken("")` now returns an **unauthenticated** scanner instead of tripping v90's empty-token validation — the honest equivalent of what an empty bearer header produced before. All real callers already guard for non-empty.

**Second commit — finish the migration by deleting code v90 obsoletes:** v90 models
`pull_request_creation_policy` natively on `Repository`, so the `repositoryWithPolicy` wrapper
struct and the hand-rolled `fetchRepository` request (added in #60 because v84 lacked the field)
are removed. `Repositories.Get` returns the same response; the rule reads
`facts.Repository.GetPullRequestCreationPolicy()` directly.

## Validation

- `make test`, golangci-lint, and `make test-e2e` against the live fixture repos: all green, no behavior change
- **Batch scan of all 93 bretfisher repositories on the new client: 0 errors, 13 seconds** (the R17 inventory savings at scale — roughly 900 requests not spent), findings consistent with the fixture goldens, and zero criticals account-wide now that R16 credits blocked external PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN
