### PR TITLE
Grade pull_request_target severity by real PR exposure

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1429,13 +1429,28 @@ Candidates, in rough order of value:
 3. ~~**`pull_request_creation_policy` (from R16).**~~ **Done 2026-08-12** as severity modulation
    inside the `pull-request-target` rule — the design PLAN preferred but deferred over rule-coupling
    concerns. It is not rule coupling: the policy is a *fact* (read from the same `GET /repos` response
-   the scan always made, decoded via a wrapper struct because go-github v84 does not model the field),
-   and rules consuming facts is exactly what the fact model is for. The finding stays critical by
-   default and drops to medium — never lower — when the repository is private or its policy is
-   `collaborators_only`, the one value proven to block external PR creation. Unknown or new policy
-   values keep the critical reading, so GitHub adding an enum value can only over-report. `gasa-fail`
-   is exactly this case (public + `collaborators_only`), so its golden finding moves critical → medium,
-   which is more accurate: that mitigation is real and the audit verified it live
+   the scan always made; go-github v90 models the field natively, retiring the interim wrapper
+   struct), and rules consuming facts is exactly what the fact model is for.
+
+   **Refined 2026-08-12 into a full severity matrix** replacing the original critical/medium split.
+   Base severity now grades who can actually reach the trigger: public + external PRs open →
+   critical; public + `collaborators_only` → low; private + external PRs open → high; private +
+   blocked + "Run workflows from fork pull requests" enabled → medium; private + blocked + fork PR
+   workflows off (the default) → low. The private cells read a new fact,
+   `GET /repos/{owner}/{repo}/actions/permissions/fork-pr-workflows-private-repos` (private-only —
+   public repos answer 422), following the established undetermined taxonomy: an unreadable policy
+   grades as if fork PR workflows were enabled, and unknown `pull_request_creation_policy` values
+   keep the severe reading, so GitHub enum additions can only over-report. On top of the matrix,
+   any `actions/checkout` version tag below v7 in the flagged workflow escalates the result one
+   level (capped at critical): checkout v7 (June 2026) refuses to fetch fork PR code under
+   `pull_request_target` unless the step opts out via `allow-unsafe-pr-checkout`, so predating it
+   forfeits that guardrail. SHA and branch checkout refs neither escalate nor clear — they carry no
+   version information, and punishing SHA pins would contradict the pinning rule. `gasa-fail`
+   (public + `collaborators_only`, checkout `@v7`) moves medium → low in its golden; the private
+   matrix cells are covered by unit tests because `gasa-fail-private`'s workflow is deliberately
+   clean. Possible follow-ups, deliberately not done yet: escalate on `allow-unsafe-pr-checkout`
+   usage, and a standalone rule for the other private fork-PR toggles (send write tokens / send
+   secrets to fork PR workflows)
 
 Implementation requirements for any of these:
 

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ The scanner runs the following checks against each repository. Findings are rate
 
 | Check | Category | Severity | What it fixes |
 |-------|----------|----------|-----------------|
-| [Pull Request Target](docs/rules/pull-request-target.md) | Workflows | Critical | `pull_request_target`, which should never be used in a public repo; the finding drops to medium (never lower) when external contributors cannot open PRs at all |
+| [Pull Request Target](docs/rules/pull-request-target.md) | Workflows | Critical | `pull_request_target`, graded by who can reach it: critical on a public repo, down to low when external PR creation is blocked and (on private repos) fork PRs cannot run workflows; +1 level when checkout predates the v7 fork-checkout protection |
 | [Action Version Pinning](docs/rules/action-version-pinning.md) | Workflows | High | Actions referenced by tag (`@v4`) or branch (`@main`) instead of commit SHA |
 | [Workflow Permissions](docs/rules/workflow-permissions.md) | Workflows | High | Workflows without an explicit `permissions` block, inheriting overly broad defaults |
 | [Write-All Workflow Permissions](docs/rules/write-all-permissions.md) | Workflows | High | Workflows granting `write-all`, the broadest possible `GITHUB_TOKEN` grant |

--- a/docs/rules/pull-request-target.md
+++ b/docs/rules/pull-request-target.md
@@ -18,20 +18,84 @@ messages:
       Use the `pull_request` event instead. If you cannot avoid
       `pull_request_target`, keep the workflow limited to trusted base-branch
       code only and never check out or execute untrusted pull request code.
-  used-restricted:
-    title: pull_request_target event is used (external PRs are restricted)
+  public-restricted:
+    title: pull_request_target event is used (external PRs are blocked)
     description: >-
       This workflow uses `pull_request_target`, which runs in the context of the
       base branch with access to a more trusted token and potentially secrets.
-      External contributors cannot currently open pull requests against this
-      repository (it is private, or its pull request creation policy is limited
-      to collaborators), so there is no untrusted pull request for the workflow
-      to act on today — but that mitigation is a repository setting, one click
-      away from disappearing, which is why this is medium rather than resolved.
+      This repository's pull request creation policy is limited to
+      collaborators, so there is no untrusted pull request for the workflow to
+      act on today — but that mitigation is a repository setting, one click away
+      from disappearing, which is why this is low rather than resolved.
     fix: >-
       Use the `pull_request` event instead. If you cannot avoid
       `pull_request_target`, keep the workflow limited to trusted base-branch
       code only and never check out or execute untrusted pull request code.
+  private:
+    title: pull_request_target event is used (private repo, external PRs allowed)
+    description: >-
+      This workflow uses `pull_request_target`, which runs in the context of the
+      base branch with access to a more trusted token and potentially secrets.
+      This repository is private, which limits who can reach it, but its pull
+      request creation policy still allows pull requests from users without
+      write access — anyone with read access can fork and open one, so the
+      untrusted-PR path is open.
+    fix: >-
+      Use the `pull_request` event instead, or set the repository's pull
+      request creation policy to collaborators only. If you cannot avoid
+      `pull_request_target`, keep the workflow limited to trusted base-branch
+      code only and never check out or execute untrusted pull request code.
+  private-fork-workflows:
+    title: pull_request_target event is used (private repo runs fork PR workflows)
+    description: >-
+      This workflow uses `pull_request_target`, which runs in the context of the
+      base branch with access to a more trusted token and potentially secrets.
+      External pull request creation is blocked on this private repository, but
+      its Actions settings enable "Run workflows from fork pull requests" —
+      which is not the default — so pull requests from forks do trigger
+      workflow runs when they occur.
+    fix: >-
+      Use the `pull_request` event instead, or disable "Run workflows from fork
+      pull requests" under Settings → Actions → General if fork contributions
+      do not need CI. If you cannot avoid `pull_request_target`, keep the
+      workflow limited to trusted base-branch code only and never check out or
+      execute untrusted pull request code.
+  private-restricted:
+    title: pull_request_target event is used (private repo, fork PR workflows off)
+    description: >-
+      This workflow uses `pull_request_target`, which runs in the context of the
+      base branch with access to a more trusted token and potentially secrets.
+      External pull request creation is blocked on this private repository and
+      fork pull requests do not run workflows, so the untrusted-PR path is
+      closed today — but both protections are repository settings, one click
+      away from disappearing, which is why this is low rather than resolved.
+    fix: >-
+      Use the `pull_request` event instead. If you cannot avoid
+      `pull_request_target`, keep the workflow limited to trusted base-branch
+      code only and never check out or execute untrusted pull request code.
+  private-fork-unknown:
+    title: pull_request_target event is used (fork PR workflow policy unverified)
+    description: >-
+      This workflow uses `pull_request_target`, which runs in the context of the
+      base branch with access to a more trusted token and potentially secrets.
+      External pull request creation is blocked on this private repository, but
+      the scanner could not read whether fork pull requests run workflows, so
+      this is graded as if they do.
+    fix: >-
+      Re-run with a token that has repository admin access so the fork PR
+      workflow policy can be verified, or use the `pull_request` event instead.
+      If you cannot avoid `pull_request_target`, keep the workflow limited to
+      trusted base-branch code only and never check out or execute untrusted
+      pull request code.
+  old-checkout:
+    title: actions/checkout predates the v7 fork-checkout protection
+    description: >-
+      Severity was raised one level because this workflow uses
+      `actions/checkout@{{.Ref}}`: starting with v7 (June 2026), checkout
+      refuses to fetch fork pull request code in `pull_request_target`
+      workflows unless explicitly overridden, and this reference predates that
+      protection.
+    fix: Update actions/checkout to v7 or later.
   pass:
     title: pull_request_target event is not used
     description: >-
@@ -69,15 +133,53 @@ This rule does not try to prove whether the workflow later checks out untrusted 
 
 ### Severity
 
-The finding is **critical** by default. It drops to **medium** — never lower — when external
-contributors cannot open pull requests against the repository at all: the repository is private, or
-its `pull_request_creation_policy` is `collaborators_only`. In that state there is no untrusted
-pull request for the workflow to act on, but the protection is a repository setting rather than a
-property of the workflow, so the dangerous pattern still warrants a finding. Only that one
-known-restricted policy value downgrades; an unknown or absent value keeps the critical reading,
-so a new GitHub policy value can only over-report, never under-report. The policy is read from the
-same `GET /repos/{owner}/{repo}` response the scan always made, so this costs no additional API
-call.
+The trigger is the same in every case; what changes the severity is who can actually reach it with
+an untrusted pull request:
+
+| Repository | External PR creation | Fork PR workflows (private-only setting) | Severity |
+|---|---|---|---|
+| public | allowed | — | **critical** |
+| public | collaborators only | — | **low** |
+| private | allowed | any | **high** |
+| private | collaborators only | "Run workflows from fork pull requests" enabled | **medium** |
+| private | collaborators only | disabled (the default) | **low** |
+| private | collaborators only | could not be read | **medium** |
+
+Two deliberate biases keep the rule from under-reporting:
+
+- Only the one known-restricted `pull_request_creation_policy` value (`collaborators_only`)
+  downgrades; an unknown or absent value keeps the severe reading, so a new GitHub policy value can
+  only over-report, never under-report.
+- When the private-repo fork PR workflow policy cannot be read (token lacks admin access, transient
+  error), the rule grades as if fork PR workflows were enabled.
+
+The policy is read from the same `GET /repos/{owner}/{repo}` response the scan always made. For
+private repositories the scanner additionally reads
+`GET /repos/{owner}/{repo}/actions/permissions/fork-pr-workflows-private-repos`, the setting under
+Settings → Actions → General that decides whether fork pull requests trigger workflow runs at all
+(public repositories answer that endpoint with 422 — the fork-PR contributor approval policy
+governs them instead).
+
+The finding never resolves entirely while `pull_request_target` is present: every mitigation above
+is a repository setting, one click away from disappearing, rather than a property of the workflow.
+
+### actions/checkout v7 escalation
+
+Whatever the table says is raised **one level** (low → medium → high → critical) when the flagged
+workflow contains an `actions/checkout` step pinned to a version tag older than **v7**.
+
+Since [checkout v7 (June 2026)](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/),
+the action refuses to fetch fork pull request code in `pull_request_target` and `workflow_run`
+workflows by default — the classic "pwn request" pattern — unless the step explicitly opts out
+with the `allow-unsafe-pr-checkout` input. GitHub also backported the protection to the other
+supported version tags in July 2026, but a workflow pinned to an old tag or SHA may still resolve
+to pre-protection code, so the scanner treats any version tag below v7 as unprotected.
+
+Only refs that look like version tags (`v4`, `4`, `v4.1.1`) are judged. A full commit SHA or a
+branch ref carries no version information, so it neither escalates nor clears — treating "unknown"
+as "old" would punish the SHA pinning every other rule asks for. The scanner also does not lower
+the severity when checkout v7+ is present: the protection can be switched off per step with
+`allow-unsafe-pr-checkout`, so its presence is never proof of safety.
 
 ## Why this matters
 

--- a/internal/scanner/facts.go
+++ b/internal/scanner/facts.go
@@ -46,6 +46,15 @@ type ActionsSettingsFacts struct {
 	DefaultWorkflowPermissions *github.DefaultWorkflowPermissionRepository
 	ForkPRContributorApproval  *github.ContributorApprovalPermissions
 
+	// PrivateForkPRWorkflows holds the private-repository fork pull request
+	// workflow policy (whether fork PRs run workflows at all, and what they
+	// receive). Only collected for private repositories — GitHub answers the
+	// endpoint with 422 for public ones, where fork PR workflow behavior is
+	// governed by the fork-PR contributor approval policy instead. Nil when the
+	// repository is public, the scan is unauthenticated, or the read failed
+	// (see Undetermined).
+	PrivateForkPRWorkflows *github.WorkflowsPermissions
+
 	// ForkPRApprovalNotApplicable is set when GitHub reports that fork-PR
 	// approval does not exist for this repository at all. Private repositories
 	// answer the endpoint with 422 "Fork PR approval is not allowed for private
@@ -77,6 +86,7 @@ const (
 	settingWorkflowPermissions = "workflow permissions"
 	settingForkPRApproval      = "fork-PR contributor approval"
 	settingSHAPinning          = "SHA pinning requirement"
+	settingForkPRWorkflows     = "private-repo fork PR workflow policy"
 )
 
 // markUndetermined records that a setting could not be read, and why.
@@ -124,6 +134,12 @@ type factCollector struct {
 	client        *github.Client
 	authenticated bool
 
+	// repoPrivate mirrors Repository.private for the repo being scanned. Set
+	// once by collectFacts before the collector goroutines start (never written
+	// after), so the settings collector knows whether to read the private-only
+	// fork PR workflow endpoint without threading the flag through every call.
+	repoPrivate bool
+
 	warnMu   sync.Mutex
 	warnings []FactWarning
 }
@@ -140,6 +156,7 @@ func (c *factCollector) collectFacts(ctx context.Context, owner, repo string, re
 	if repository != nil && repository.DefaultBranch != nil && *repository.DefaultBranch != "" {
 		facts.DefaultBranch = *repository.DefaultBranch
 	}
+	c.repoPrivate = repository.GetPrivate()
 
 	// The four collectors hit independent GitHub endpoints, so run them
 	// concurrently. Each goroutine writes only its own local, read back after

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -605,38 +605,83 @@ func actionsObservedDisabled(facts *ScanFacts) bool {
 // over-report, never under-report.
 const prCreationPolicyCollaboratorsOnly = "collaborators_only"
 
-// externalPRCreationRestricted reports whether external contributors are unable
-// to open pull requests against this repository — private repositories take
-// only collaborator PRs by nature, and the creation policy can restrict public
-// ones the same way. When true there is no untrusted pull request for a
-// pull_request_target workflow to act on today.
-func externalPRCreationRestricted(facts *ScanFacts) bool {
-	if facts.Repository.GetPrivate() {
-		return true
+// dangerousTriggerBase grades how exposed a pull_request_target workflow is to
+// untrusted pull requests, returning the base severity and the message key
+// that explains it. The trigger is the same in every cell; what changes is who
+// can reach it:
+//
+//	public,  external PRs open     → critical
+//	public,  external PRs blocked  → low
+//	private, external PRs open     → high
+//	private, external PRs blocked, fork PRs run workflows → medium
+//	private, external PRs blocked, fork PRs cannot run    → low
+//
+// Only the one known-restricted policy value downgrades; an unknown or absent
+// policy keeps the severe reading so a new GitHub enum value can only
+// over-report, never under-report. The same bias applies when the private-repo
+// fork PR workflow policy could not be read: unknown grades as medium, not low.
+func dangerousTriggerBase(facts *ScanFacts) (string, string) {
+	private := facts.Repository.GetPrivate()
+	restricted := facts.Repository.GetPullRequestCreationPolicy() == prCreationPolicyCollaboratorsOnly
+	switch {
+	case !private && !restricted:
+		return SeverityCritical, "used"
+	case !private:
+		return SeverityLow, "public-restricted"
+	case !restricted:
+		return SeverityHigh, "private"
 	}
-	return facts.Repository.GetPullRequestCreationPolicy() == prCreationPolicyCollaboratorsOnly
+	forkPolicy := facts.ActionsSettings.PrivateForkPRWorkflows
+	switch {
+	case forkPolicy == nil:
+		return SeverityMedium, "private-fork-unknown"
+	case forkPolicy.GetRunWorkflowsFromForkPullRequests():
+		return SeverityMedium, "private-fork-workflows"
+	default:
+		return SeverityLow, "private-restricted"
+	}
+}
+
+// escalateSeverity raises a severity one level, capped at critical. Info is
+// left alone: it marks non-findings (successes, undetermined notes), which an
+// escalation modifier has no business touching.
+func escalateSeverity(severity string) string {
+	switch severity {
+	case SeverityLow:
+		return SeverityMedium
+	case SeverityMedium:
+		return SeverityHigh
+	case SeverityHigh:
+		return SeverityCritical
+	default:
+		return severity
+	}
 }
 
 func evaluateDangerousWorkflowRule(facts *ScanFacts) []Finding {
-	// The trigger is the same, but the blast radius is not: where external
-	// contributors cannot open PRs at all, there is no untrusted head for the
-	// workflow to check out today. Medium instead of critical — the mitigation
-	// is a repository setting, one click away from disappearing, so it never
-	// downgrades further than that.
-	severity, msgKey := SeverityCritical, "used"
-	if externalPRCreationRestricted(facts) {
-		severity, msgKey = SeverityMedium, "used-restricted"
-	}
+	severity, msgKey := dangerousTriggerBase(facts)
 
 	var findings []Finding
 	for _, wf := range facts.Workflows {
 		if !wf.Valid || !hasDangerousTrigger(wf.Workflow.On) {
 			continue
 		}
+		// actions/checkout v7 refuses to fetch fork PR code under
+		// pull_request_target by default, removing the classic pwn-request
+		// footgun. A checkout pinned to an older version tag forfeits that
+		// guardrail, so the finding climbs one level. Graded per workflow, not
+		// per repository: one workflow can carry the old checkout while
+		// another does not.
+		wfSeverity := severity
 		msg := ruleMessage(ruleNamePullRequestTarget, msgKey, nil)
+		if ref, outdated := outdatedCheckoutRef(wf.Workflow); outdated {
+			wfSeverity = escalateSeverity(severity)
+			note := ruleMessage(ruleNamePullRequestTarget, "old-checkout", map[string]string{"Ref": ref})
+			msg.Description += " " + note.Description
+		}
 		findings = append(findings, Finding{
 			ID:          fmt.Sprintf("dangerous-trigger-%s", wf.Path),
-			Severity:    severity,
+			Severity:    wfSeverity,
 			Title:       msg.Title,
 			Description: msg.Description,
 			File:        wf.Path,

--- a/internal/scanner/settings.go
+++ b/internal/scanner/settings.go
@@ -124,7 +124,11 @@ func (c *factCollector) recordSettingsFetchFailure(facts *ActionsSettingsFacts, 
 		// claim about a setting the scanner never managed to read.
 		cause := describeFetchError(err)
 		c.addWarning("actions settings", cause)
-		for _, setting := range []string{settingAllowedActions, settingWorkflowPermissions, settingForkPRApproval, settingSHAPinning} {
+		settings := []string{settingAllowedActions, settingWorkflowPermissions, settingForkPRApproval, settingSHAPinning}
+		if c.repoPrivate {
+			settings = append(settings, settingForkPRWorkflows)
+		}
+		for _, setting := range settings {
 			facts.markUndetermined(setting, cause)
 		}
 	}
@@ -199,6 +203,17 @@ func fetchAuthenticatedActionsSettings(ctx context.Context, c *factCollector, ow
 		}
 	}
 
+	fetchForkPRApprovalPolicy(ctx, c, owner, repo, facts, repoFull, dbg)
+
+	if c.repoPrivate {
+		fetchPrivateForkPRWorkflowSettings(ctx, c, owner, repo, facts, repoFull, dbg)
+	}
+}
+
+// fetchForkPRApprovalPolicy reads the fork-PR contributor approval policy,
+// treating GitHub's 422 "not allowed for private repositories" as a determinate
+// not-applicable answer rather than a failed read.
+func fetchForkPRApprovalPolicy(ctx context.Context, c *factCollector, owner, repo string, facts *ActionsSettingsFacts, repoFull string, dbg DebugLogger) {
 	if dbg != nil {
 		dbg(repoFull, "GET /repos/"+repoFull+"/actions/permissions/fork-pr-contributor-approval")
 	}
@@ -224,6 +239,48 @@ func fetchAuthenticatedActionsSettings(ctx context.Context, c *factCollector, ow
 		c.addWarning("fork-PR contributor approval", describeFetchError(err))
 		if dbg != nil {
 			dbg(repoFull, "fork-pr-approval fetch could not be determined: "+describeFetchError(err))
+		}
+	}
+}
+
+// fetchPrivateForkPRWorkflowSettings reads the private-repository fork pull
+// request workflow policy: whether fork PRs run workflows at all, and what
+// those runs receive (write tokens, secrets, approval gates). The
+// pull-request-target rule uses it to grade how exposed a private repository
+// actually is. Only called for private repositories — GitHub rejects the
+// endpoint with 422 for public ones, where the fork-PR contributor approval
+// policy governs instead.
+func fetchPrivateForkPRWorkflowSettings(ctx context.Context, c *factCollector, owner, repo string, facts *ActionsSettingsFacts, repoFull string, dbg DebugLogger) {
+	if dbg != nil {
+		dbg(repoFull, "GET /repos/"+repoFull+"/actions/permissions/fork-pr-workflows-private-repos")
+	}
+	perms, resp, err := c.client.Repositories.GetPrivateRepoForkPRWorkflowSettings(ctx, owner, repo)
+	switch {
+	case err == nil:
+		facts.PrivateForkPRWorkflows = perms
+		if dbg != nil {
+			dbg(repoFull, fmt.Sprintf("fork-pr-workflows: run=%v write_tokens=%v secrets=%v require_approval=%v",
+				perms.GetRunWorkflowsFromForkPullRequests(), perms.GetSendWriteTokensToWorkflows(),
+				perms.GetSendSecretsAndVariables(), perms.GetRequireApprovalForForkPRWorkflows()))
+		}
+	case resp != nil && resp.Response != nil && resp.StatusCode == http.StatusUnprocessableEntity:
+		// "Fork PR workflow settings is not allowed for public repositories."
+		// Only private repositories are queried, so this should not happen —
+		// but it is a determinate answer that the setting does not exist here,
+		// not a failed read, so it must not be reported as undetermined.
+		if dbg != nil {
+			dbg(repoFull, "fork-pr-workflows: not applicable to this repository (HTTP 422)")
+		}
+	case isAccessDenied(resp):
+		facts.markUndetermined(settingForkPRWorkflows, fmt.Sprintf("GitHub returned %d — the token cannot read this setting", resp.StatusCode))
+		if dbg != nil {
+			dbg(repoFull, fmt.Sprintf("fork-pr-workflows fetch: status %d — undetermined", resp.StatusCode))
+		}
+	default:
+		facts.markUndetermined(settingForkPRWorkflows, describeFetchError(err))
+		c.addWarning("private-repo fork PR workflows", describeFetchError(err))
+		if dbg != nil {
+			dbg(repoFull, "fork-pr-workflows fetch could not be determined: "+describeFetchError(err))
 		}
 	}
 }

--- a/internal/scanner/settings_test.go
+++ b/internal/scanner/settings_test.go
@@ -451,6 +451,76 @@ func TestFetchAuthenticatedSettings_TransientErrorsWarn(t *testing.T) {
 	}
 }
 
+// The private-repo fork PR workflow endpoint is only read when the repository
+// is private, and its three failure shapes follow the taxonomy of the other
+// sub-calls: success stores the policy, a denial marks it undetermined without
+// warning, a transient error marks it undetermined and warns.
+func TestFetchPrivateForkPRWorkflowSettings(t *testing.T) {
+	const path = "/repos/owner/repo/actions/permissions/fork-pr-workflows-private-repos"
+	base := func(mux *http.ServeMux) {
+		handleJSON(mux, "/repos/owner/repo/actions/permissions", map[string]any{"enabled": true, "allowed_actions": "selected"})
+		handle404(mux,
+			"/repos/owner/repo/actions/permissions/workflow",
+			"/repos/owner/repo/actions/permissions/fork-pr-contributor-approval",
+		)
+	}
+
+	t.Run("public repos are never queried", func(t *testing.T) {
+		s, mux := newTestScanner(t, true)
+		base(mux)
+		mux.HandleFunc(path, func(http.ResponseWriter, *http.Request) {
+			t.Error("fork-pr-workflows endpoint must not be called for a public repo")
+		})
+		collector := newTestFactCollector(s)
+		facts := collector.collectActionsSettingsFacts(context.Background(), "owner", "repo", nil)
+		if _, undetermined := facts.undeterminedCause(settingForkPRWorkflows); undetermined {
+			t.Fatal("public repo must not mark the fork PR workflow policy undetermined")
+		}
+	})
+
+	t.Run("private repo stores the policy", func(t *testing.T) {
+		s, mux := newTestScanner(t, true)
+		base(mux)
+		handleJSON(mux, path, map[string]any{"run_workflows_from_fork_pull_requests": true})
+		collector := newTestFactCollector(s)
+		collector.repoPrivate = true
+		facts := collector.collectActionsSettingsFacts(context.Background(), "owner", "repo", nil)
+		if !facts.PrivateForkPRWorkflows.GetRunWorkflowsFromForkPullRequests() {
+			t.Fatalf("PrivateForkPRWorkflows = %+v, want run_workflows true", facts.PrivateForkPRWorkflows)
+		}
+	})
+
+	t.Run("denial marks undetermined without warning", func(t *testing.T) {
+		s, mux := newTestScanner(t, true)
+		base(mux)
+		handle404(mux, path)
+		collector := newTestFactCollector(s)
+		collector.repoPrivate = true
+		facts := collector.collectActionsSettingsFacts(context.Background(), "owner", "repo", nil)
+		if _, undetermined := facts.undeterminedCause(settingForkPRWorkflows); !undetermined {
+			t.Fatal("a denied read must mark the fork PR workflow policy undetermined")
+		}
+		if len(collector.warnings) != 0 {
+			t.Fatalf("a denial must not warn, got %+v", collector.warnings)
+		}
+	})
+
+	t.Run("transient error marks undetermined and warns", func(t *testing.T) {
+		s, mux := newTestScanner(t, true)
+		base(mux)
+		handle500(mux, path)
+		collector := newTestFactCollector(s)
+		collector.repoPrivate = true
+		facts := collector.collectActionsSettingsFacts(context.Background(), "owner", "repo", nil)
+		if _, undetermined := facts.undeterminedCause(settingForkPRWorkflows); !undetermined {
+			t.Fatal("a transient failure must mark the fork PR workflow policy undetermined")
+		}
+		if len(collector.warnings) != 1 || collector.warnings[0].Area != "private-repo fork PR workflows" {
+			t.Fatalf("warnings = %+v, want one for the fork PR workflow read", collector.warnings)
+		}
+	})
+}
+
 // A 403/404 on the sub-calls leaves the values unset and raises no incomplete
 // warning — the denial is determinate as an HTTP outcome, so it is not a
 // transient failure. The rules still surface it as an undetermined finding

--- a/internal/scanner/workflow.go
+++ b/internal/scanner/workflow.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/google/go-github/v90/github"
@@ -210,6 +211,51 @@ type ActionRef struct {
 	name    string
 	version string
 	line    int
+}
+
+// checkoutSafeMajor is the first actions/checkout major release that refuses
+// to fetch fork pull request code in pull_request_target and workflow_run
+// workflows by default (June 2026). Earlier version tags predate that
+// guardrail, so a pull_request_target workflow using one is graded a level
+// more severe.
+const checkoutSafeMajor = 7
+
+// versionTagMajorRegex extracts the major number from a version-tag-shaped ref
+// such as v4, 4, v4.1.1, or v4-beta. Refs that do not look like version tags
+// (branches, full SHAs) carry no version information and never match.
+var versionTagMajorRegex = regexp.MustCompile(`^v?(\d+)([.-].*)?$`)
+
+// outdatedCheckoutRef returns the first actions/checkout reference in the
+// workflow whose version tag predates the v7 fork-checkout protection, walking
+// jobs in sorted-name order so the answer is deterministic. Refs that are not
+// version tags — a full SHA, a branch — neither escalate nor clear: they carry
+// no version information, and treating "unknown" as "old" would punish the SHA
+// pinning every other rule asks for.
+func outdatedCheckoutRef(workflow *WorkflowFile) (string, bool) {
+	if workflow == nil {
+		return "", false
+	}
+	jobNames := make([]string, 0, len(workflow.Jobs))
+	for name := range workflow.Jobs {
+		jobNames = append(jobNames, name)
+	}
+	sort.Strings(jobNames)
+	for _, name := range jobNames {
+		for _, step := range workflow.Jobs[name].Steps {
+			action, ok := parseActionRef(step.Uses)
+			if !ok || !strings.EqualFold(action.name, "actions/checkout") {
+				continue
+			}
+			m := versionTagMajorRegex.FindStringSubmatch(action.version)
+			if m == nil {
+				continue
+			}
+			if major, err := strconv.Atoi(m[1]); err == nil && major < checkoutSafeMajor {
+				return action.version, true
+			}
+		}
+	}
+	return "", false
 }
 
 func findUnpinnedActionsInWorkflow(workflow *WorkflowFile, content string) []ActionRef {

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -396,35 +396,57 @@ func TestEvaluateWriteAllPermissionsRule(t *testing.T) {
 	})
 }
 
-// pull_request_target's blast radius depends on whether an external contributor
-// can open a PR at all. The severity must track that — and must fail severe
-// when the policy is unknown, so a new GitHub enum value can only over-report.
-func TestEvaluateDangerousWorkflowRule_SeverityTracksPRCreationPolicy(t *testing.T) {
-	prtWorkflow := func(t *testing.T) []WorkflowFact {
-		t.Helper()
-		content := "on: pull_request_target\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n"
-		workflow := &WorkflowFile{}
-		if err := yaml.Unmarshal([]byte(content), workflow); err != nil {
-			t.Fatalf("yaml.Unmarshal() error: %v", err)
+// prtWorkflowFacts builds a single valid pull_request_target workflow whose
+// only step is the given uses/run line, for exercising the dangerous-trigger
+// severity grading.
+func prtWorkflowFacts(t *testing.T, step string) []WorkflowFact {
+	t.Helper()
+	content := "on: pull_request_target\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - " + step + "\n"
+	workflow := &WorkflowFile{}
+	if err := yaml.Unmarshal([]byte(content), workflow); err != nil {
+		t.Fatalf("yaml.Unmarshal() error: %v", err)
+	}
+	return []WorkflowFact{{Path: ".github/workflows/prt.yml", Content: content, Workflow: workflow, Valid: true}}
+}
+
+// pull_request_target's blast radius depends on who can actually reach it with
+// an untrusted PR: repo visibility, the PR creation policy, and (for private
+// repos) whether fork PRs run workflows at all. Unknown values must grade
+// severe so a new GitHub enum value — or an unreadable setting — can only
+// over-report, never under-report.
+func TestEvaluateDangerousWorkflowRule_SeverityMatrix(t *testing.T) {
+	repo := func(private bool, policy string) *github.Repository {
+		r := &github.Repository{Private: github.Ptr(private)}
+		if policy != "" {
+			r.PullRequestCreationPolicy = github.Ptr(policy)
 		}
-		return []WorkflowFact{{Path: ".github/workflows/prt.yml", Content: content, Workflow: workflow, Valid: true}}
+		return r
+	}
+	forkRun := func(run bool) ActionsSettingsFacts {
+		return ActionsSettingsFacts{PrivateForkPRWorkflows: &github.WorkflowsPermissions{
+			RunWorkflowsFromForkPullRequests: github.Ptr(run),
+		}}
 	}
 
 	cases := []struct {
 		name         string
 		facts        *ScanFacts
 		wantSeverity string
-		wantRestrict bool
+		wantTitle    string
 	}{
-		{"public, policy all", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false), PullRequestCreationPolicy: github.Ptr("all")}}, SeverityCritical, false},
-		{"public, policy unknown stays critical", &ScanFacts{Repository: &github.Repository{}}, SeverityCritical, false},
-		{"public, collaborators only", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(false), PullRequestCreationPolicy: github.Ptr("collaborators_only")}}, SeverityMedium, true},
-		{"private repository", &ScanFacts{Repository: &github.Repository{Private: github.Ptr(true), PullRequestCreationPolicy: github.Ptr("all")}}, SeverityMedium, true},
+		{"public, policy all", &ScanFacts{Repository: repo(false, "all")}, SeverityCritical, "pull_request_target event is used"},
+		{"public, policy unknown stays critical", &ScanFacts{Repository: &github.Repository{}}, SeverityCritical, "pull_request_target event is used"},
+		{"public, collaborators only", &ScanFacts{Repository: repo(false, "collaborators_only")}, SeverityLow, "external PRs are blocked"},
+		{"private, policy all", &ScanFacts{Repository: repo(true, "all"), ActionsSettings: forkRun(false)}, SeverityHigh, "external PRs allowed"},
+		{"private, policy unknown stays high", &ScanFacts{Repository: repo(true, "")}, SeverityHigh, "external PRs allowed"},
+		{"private, blocked, fork PR workflows enabled", &ScanFacts{Repository: repo(true, "collaborators_only"), ActionsSettings: forkRun(true)}, SeverityMedium, "runs fork PR workflows"},
+		{"private, blocked, fork PR workflows disabled", &ScanFacts{Repository: repo(true, "collaborators_only"), ActionsSettings: forkRun(false)}, SeverityLow, "fork PR workflows off"},
+		{"private, blocked, fork policy unreadable grades as enabled", &ScanFacts{Repository: repo(true, "collaborators_only")}, SeverityMedium, "unverified"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.facts.Workflows = prtWorkflow(t)
+			tc.facts.Workflows = prtWorkflowFacts(t, "run: echo hi")
 			findings := evaluateDangerousWorkflowRule(tc.facts)
 			if len(findings) != 1 {
 				t.Fatalf("findings = %+v, want one", findings)
@@ -432,9 +454,76 @@ func TestEvaluateDangerousWorkflowRule_SeverityTracksPRCreationPolicy(t *testing
 			if findings[0].Severity != tc.wantSeverity {
 				t.Fatalf("severity = %q, want %q", findings[0].Severity, tc.wantSeverity)
 			}
-			restricted := strings.Contains(findings[0].Title, "restricted")
-			if restricted != tc.wantRestrict {
-				t.Fatalf("title = %q, restricted-variant = %v, want %v", findings[0].Title, restricted, tc.wantRestrict)
+			if !strings.Contains(findings[0].Title, tc.wantTitle) {
+				t.Fatalf("title = %q, want it to contain %q", findings[0].Title, tc.wantTitle)
+			}
+		})
+	}
+}
+
+// A checkout older than v7 predates the fork-checkout protection, so whatever
+// the matrix graded climbs one level — and critical stays critical.
+func TestEvaluateDangerousWorkflowRule_OldCheckoutEscalates(t *testing.T) {
+	cases := []struct {
+		name         string
+		private      bool
+		policy       string
+		step         string
+		wantSeverity string
+		wantNote     bool
+	}{
+		{"low escalates to medium", false, "collaborators_only", "uses: actions/checkout@v4", SeverityMedium, true},
+		{"critical stays critical", false, "all", "uses: actions/checkout@v4", SeverityCritical, true},
+		{"checkout v7 does not escalate", false, "collaborators_only", "uses: actions/checkout@v7", SeverityLow, false},
+		{"SHA-pinned checkout carries no version info", false, "collaborators_only", "uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0", SeverityLow, false},
+		{"other actions are not checkout", false, "collaborators_only", "uses: actions/setup-go@v5", SeverityLow, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			facts := &ScanFacts{Repository: &github.Repository{
+				Private:                   github.Ptr(tc.private),
+				PullRequestCreationPolicy: github.Ptr(tc.policy),
+			}}
+			facts.Workflows = prtWorkflowFacts(t, tc.step)
+			findings := evaluateDangerousWorkflowRule(facts)
+			if len(findings) != 1 {
+				t.Fatalf("findings = %+v, want one", findings)
+			}
+			if findings[0].Severity != tc.wantSeverity {
+				t.Fatalf("severity = %q, want %q", findings[0].Severity, tc.wantSeverity)
+			}
+			hasNote := strings.Contains(findings[0].Description, "raised one level")
+			if hasNote != tc.wantNote {
+				t.Fatalf("description = %q, escalation note = %v, want %v", findings[0].Description, hasNote, tc.wantNote)
+			}
+		})
+	}
+}
+
+func TestOutdatedCheckoutRef(t *testing.T) {
+	cases := []struct {
+		uses string
+		want bool
+	}{
+		{"actions/checkout@v4", true},
+		{"actions/checkout@4", true},
+		{"actions/checkout@v6.1.2", true},
+		{"actions/checkout@v6-beta", true},
+		{"actions/checkout@v7", false},
+		{"actions/checkout@v7.0.0", false},
+		{"actions/checkout@v12", false},
+		{"actions/checkout@main", false},
+		{"actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0", false},
+		{"someone/checkout@v4", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.uses, func(t *testing.T) {
+			wf := &WorkflowFile{Jobs: map[string]WorkflowJob{
+				"build": {Steps: []WorkflowStep{{Uses: tc.uses}}},
+			}}
+			if _, got := outdatedCheckoutRef(wf); got != tc.want {
+				t.Fatalf("outdatedCheckoutRef(%q) = %v, want %v", tc.uses, got, tc.want)
 			}
 		})
 	}

--- a/testdata/e2e/expected/gasa-fail.golden.json
+++ b/testdata/e2e/expected/gasa-fail.golden.json
@@ -89,7 +89,7 @@
     {
       "rule": "workflows/pull-request-target",
       "id": "dangerous-trigger-.github/workflows/bad-pull-request-target.yaml",
-      "severity": "medium",
+      "severity": "low",
       "success": false
     },
     {


### PR DESCRIPTION
## What

Replaces the pull-request-target rule's critical/medium split with a severity matrix graded by who can actually reach the trigger with an untrusted pull request, plus a one-level escalation when the workflow's `actions/checkout` predates v7.

| Repository | External PR creation | Fork PR workflows (private-only) | Severity |
|---|---|---|---|
| public | allowed | — | **critical** |
| public | collaborators only | — | **low** |
| private | allowed | any | **high** |
| private | collaborators only | enabled | **medium** |
| private | collaborators only | disabled (default) | **low** |
| private | collaborators only | unreadable | **medium** |

On top of the matrix, an `actions/checkout` version tag below **v7** raises the result one level (capped at critical): [checkout v7 (June 2026)](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/) refuses to fetch fork PR code under `pull_request_target` unless the step opts out via `allow-unsafe-pr-checkout`. SHA and branch checkout refs neither escalate nor clear — they carry no version information, and punishing SHA pins would contradict the pinning rule.

## How

- New fact: `GET /repos/{owner}/{repo}/actions/permissions/fork-pr-workflows-private-repos` (go-github v90 `GetPrivateRepoForkPRWorkflowSettings`), fetched only for private repos — public repos answer 422. Failure taxonomy matches the other settings sub-calls: denial → undetermined, transient → undetermined + incomplete warning.
- Unknown values always grade severe: an unknown `pull_request_creation_policy` reads as "external PRs open"; an unreadable fork-PR policy reads as "fork PR workflows enabled".
- Six message keys replace `used`/`used-restricted` so every cell explains itself; the escalation appends an `old-checkout` note to the description.

## Testing

- Unit: full matrix (8 cases), escalation table (5 cases incl. critical cap and SHA neutrality), `outdatedCheckoutRef` ref parsing (10 cases), collector tests for the new endpoint (4 subtests).
- e2e: `gasa-fail` golden moves medium → **low** (public + collaborators_only + checkout@v7). Private matrix cells are unit-covered because `gasa-fail-private`'s workflow is deliberately clean.

Follow-ups deliberately not done: escalate on `allow-unsafe-pr-checkout` usage; standalone rule for the other private fork-PR toggles (send write tokens / secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN
