### PR TITLE
Split same-owner pinning ignores and grade same-owner refs by ref shape

### DIFF
--- a/.gasa.sample.yaml
+++ b/.gasa.sample.yaml
@@ -28,10 +28,14 @@ overrides:
 # Configure rule-specific behavior.
 rule_options:
   workflows/action-version-pinning:
-    # Ignore mutable refs for actions in the same GitHub owner as the repo
-    # being scanned. This is useful when you control those actions through
-    # your own release and update process.
-    ignore_same_owner: true
+    # Ignore mutable refs owned by the same GitHub user/org as the repo being
+    # scanned. Without these, same-owner refs still flag: low when pinned to a
+    # version tag, medium when pinned to a branch. Use them when you control
+    # those repos through your own release and update process.
+    ignore_same_owner_actions: true
+    ignore_same_owner_reusable_workflows: true
+    # Legacy shorthand for enabling both options above:
+    # ignore_same_owner: true
 
   updates/update-tool-configuration:
     # Only run the update tool configuration rule when the repository actually

--- a/PLAN.md
+++ b/PLAN.md
@@ -1452,6 +1452,21 @@ Candidates, in rough order of value:
    usage, and a standalone rule for the other private fork-PR toggles (send write tokens / send
    secrets to fork PR workflows)
 
+4. ~~**Same-owner pinning tiers (from the 2026-08-12 account-scan review).**~~ **Done 2026-08-12.**
+   The 93-repo account scan (run with `--no-config`, so `.gasa.yaml`'s `ignore_same_owner` never
+   applied) surfaced that same-owner reusable workflows graded identically to third-party refs. The
+   single `ignore_same_owner` option split into two per-kind options —
+   `ignore_same_owner_actions` and `ignore_same_owner_reusable_workflows` — with the legacy key
+   kept as shorthand for both. Default grading changed: same-owner refs now flag **low** when
+   pinned to a version tag (moves only on publish) and **medium** when pinned to a branch (moves on
+   every push, so a compromise of that one repo pivots into every caller on the next commit);
+   third-party refs stay high. The rule doc now spells out the cross-repo pivot risk, the
+   mitigation pairing (version tag + immutable releases on the referenced repo), and GitHub's own
+   `sha_pinning_required` enforcement exemption — "Reusable workflows can still be referenced by
+   tag", tags only, meaning a same-owner reusable workflow pinned to `@main` stops running the
+   moment that setting is enabled. Note the exemption in GitHub's docs is *not* scoped to same
+   user/org — it covers reusable workflows referenced by tag generally
+
 Implementation requirements for any of these:
 
 - stable rule ID, front-matter metadata, a `docs/rules/` page, unit tests, and pass/fail fixture coverage in the Phase 12 repos

--- a/README.md
+++ b/README.md
@@ -278,7 +278,8 @@ rules:
 
 rule_options:
   workflows/action-version-pinning:
-    ignore_same_owner: true
+    ignore_same_owner_actions: true
+    ignore_same_owner_reusable_workflows: true
   updates/update-tool-configuration:
     require_workflows: true
 
@@ -371,7 +372,7 @@ The scanner runs the following checks against each repository. Findings are rate
 | Check | Category | Severity | What it fixes |
 |-------|----------|----------|-----------------|
 | [Pull Request Target](docs/rules/pull-request-target.md) | Workflows | Critical | `pull_request_target`, graded by who can reach it: critical on a public repo, down to low when external PR creation is blocked and (on private repos) fork PRs cannot run workflows; +1 level when checkout predates the v7 fork-checkout protection |
-| [Action Version Pinning](docs/rules/action-version-pinning.md) | Workflows | High | Actions referenced by tag (`@v4`) or branch (`@main`) instead of commit SHA |
+| [Action Version Pinning](docs/rules/action-version-pinning.md) | Workflows | High | Actions referenced by tag (`@v4`) or branch (`@main`) instead of commit SHA; same-owner refs grade lower (low for version tags, medium for branches) and can be ignored per kind via config |
 | [Workflow Permissions](docs/rules/workflow-permissions.md) | Workflows | High | Workflows without an explicit `permissions` block, inheriting overly broad defaults |
 | [Write-All Workflow Permissions](docs/rules/write-all-permissions.md) | Workflows | High | Workflows granting `write-all`, the broadest possible `GITHUB_TOKEN` grant |
 | [Default Workflow Permissions](docs/rules/default-workflow-permissions.md) | Settings | High | Repository default `GITHUB_TOKEN` set to read-write instead of read-only |

--- a/docs/rules/action-version-pinning.md
+++ b/docs/rules/action-version-pinning.md
@@ -142,7 +142,7 @@ findings by default. Two mitigations shrink the window:
 ### Relation to GitHub's SHA-pinning enforcement setting
 
 GitHub's repository setting **"Require actions to be pinned to a full-length commit SHA"** (see the
-[`sha-pinning-required`](sha-pinning-required.md) rule) enforces SHA pinning at run time, with one
+[`sha-pinning-required`](sha-pinning-required.md) rule) enforces SHA pinning at runtime, with one
 documented exemption: "Reusable workflows can still be referenced by tag." Note the exemption is
 for **tags only** — a reusable workflow referenced by *branch* is still refused when enforcement is
 on. So a same-owner reusable workflow pinned to a version tag survives enforcement, but one pinned

--- a/docs/rules/action-version-pinning.md
+++ b/docs/rules/action-version-pinning.md
@@ -13,6 +13,33 @@ messages:
       This action uses a mutable reference '{{.Ref}}'. Tags and branches can be
       moved, potentially introducing malicious code.
     fix: Pin to a specific commit SHA instead of '{{.Ref}}'.
+  unpinned-same-owner-version:
+    title: "Same-owner {{.Kind}} pinned to a version tag: {{.Action}}"
+    description: >-
+      This {{.Kind}} uses the mutable version tag '{{.Ref}}', but it is owned
+      by the same user or org as this repository, and a version tag moves only
+      when its owner publishes — so this is graded low rather than high. The
+      risk is not zero: same owner is not same repo, and a compromise of that
+      repository pivots here on its next tag move.
+    fix: >-
+      Pin to a specific commit SHA, or keep the tag and enable immutable
+      releases on the {{.Action}} repository so published tags cannot be moved.
+      To silence same-owner refs entirely, set the rule's
+      `ignore_same_owner_actions` / `ignore_same_owner_reusable_workflows`
+      config options.
+  unpinned-same-owner-branch:
+    title: "Same-owner {{.Kind}} pinned to a branch: {{.Action}}"
+    description: >-
+      This {{.Kind}} is owned by the same user or org as this repository, but
+      it is referenced by '{{.Ref}}', which does not look like a version tag —
+      a branch moves on every push. Same owner is not same repo: a compromise
+      of that repository runs attacker code in this one on the very next
+      commit, with no release step in between.
+    fix: >-
+      Pin to a specific commit SHA, or at least to a version tag on a
+      repository with immutable releases enabled. To silence same-owner refs
+      entirely, set the rule's `ignore_same_owner_actions` /
+      `ignore_same_owner_reusable_workflows` config options.
   pass:
     title: Action versions are pinned safely
     description: >-
@@ -60,24 +87,67 @@ A reference counts as pinned when its version is a hex SHA of 40 characters (SHA
 characters (SHA-256, accepted for forward compatibility). Anything else — a tag, a branch,
 a short SHA — is treated as unpinned.
 
-Optional config behavior:
+### Severity tiers
 
-- if `.gasa.yml` sets:
+Tags like `@v4`, branches like `@main`, and reusable workflows referenced by tag or branch are all
+treated as unpinned, but they are not all graded the same:
+
+| Reference | Ref shape | Severity |
+|---|---|---|
+| owned by anyone else | any mutable ref | **high** |
+| same user/org as the scanned repo | version tag (`v4`, `4`, `v4.1.1`) | **low** |
+| same user/org as the scanned repo | branch or anything else (`main`) | **medium** |
+
+A ref counts as a version tag when it looks like one (`v?<digits>` optionally followed by `.`/`-`
+and more); everything else is treated as a branch. The distinction matters because a version tag
+moves only when its owner publishes, while a branch moves on every push.
+
+### Optional config
 
 ```yaml
 rule_options:
   workflows/action-version-pinning:
-    ignore_same_owner: true
+    ignore_same_owner_actions: true
+    ignore_same_owner_reusable_workflows: true
 ```
 
-- then the rule ignores mutable refs for actions whose owner matches the repository owner being scanned
-- local actions referenced with `./...` are also treated as owner-controlled and are ignored
+- `ignore_same_owner_actions` — ignore mutable refs to *actions* whose owner matches the repository
+  owner being scanned
+- `ignore_same_owner_reusable_workflows` — the same, for *reusable workflow calls*
+  (`jobs.<job_id>.uses`)
+- `ignore_same_owner: true` — legacy switch, equivalent to enabling both of the above
 
-This means tags like `@v4`, branches like `@main`, and reusable workflows referenced by tag or branch are all treated as unpinned.
+Local actions referenced with `./...` never produce findings — both extraction paths skip them.
 
 ## Why this matters
 
-Tags and branches are mutable. If an upstream action is compromised, a moved tag can make your workflow run attacker-controlled code on the next trigger. A full commit SHA is the only immutable reference GitHub recommends for third-party actions.
+Tags and branches are mutable. If an upstream action is compromised, a moved tag can make your
+workflow run attacker-controlled code on the next trigger. A full commit SHA is the only immutable
+reference GitHub recommends for third-party actions.
+
+### Same owner is not same repo
+
+A ref like `youruser/some-workflow@main` feels internal, but the trust boundary is the
+*repository*, not the account: a leaked PAT or a compromised collaborator with write access to just
+that one repository pivots into every caller on the next push to `main` — no release, no review in
+the calling repo, nothing to notice. That cross-repo pivot is why same-owner refs still produce
+findings by default. Two mitigations shrink the window:
+
+- pin to a **version tag** instead of a branch, so the ref only moves on a deliberate publish
+  (this is the low-severity tier above), and
+- enable **[immutable releases](https://docs.github.com/en/repositories/releasing-projects-on-github/immutable-releases)**
+  on the action or reusable-workflow repository, so published tags cannot be moved at all —
+  making a tag pin behave like a SHA pin
+
+### Relation to GitHub's SHA-pinning enforcement setting
+
+GitHub's repository setting **"Require actions to be pinned to a full-length commit SHA"** (see the
+[`sha-pinning-required`](sha-pinning-required.md) rule) enforces SHA pinning at run time, with one
+documented exemption: "Reusable workflows can still be referenced by tag." Note the exemption is
+for **tags only** — a reusable workflow referenced by *branch* is still refused when enforcement is
+on. So a same-owner reusable workflow pinned to a version tag survives enforcement, but one pinned
+to `@main` will stop running the moment that setting is enabled — one more reason the branch tier
+grades higher than the version-tag tier.
 
 ## Bad example
 

--- a/internal/scanner/config.go
+++ b/internal/scanner/config.go
@@ -28,7 +28,17 @@ type ConfigRuleOptions struct {
 }
 
 type ActionVersionPinningRuleOptions struct {
+	// IgnoreSameOwner ignores every same-owner mutable ref — actions and
+	// reusable workflows alike. Legacy switch kept as shorthand for enabling
+	// both narrower options below at once.
 	IgnoreSameOwner bool `yaml:"ignore_same_owner"`
+	// IgnoreSameOwnerActions ignores mutable refs to actions whose owner
+	// matches the repository owner being scanned.
+	IgnoreSameOwnerActions bool `yaml:"ignore_same_owner_actions"`
+	// IgnoreSameOwnerReusableWorkflows ignores mutable refs to reusable
+	// workflow calls (jobs.<id>.uses) whose owner matches the repository
+	// owner being scanned.
+	IgnoreSameOwnerReusableWorkflows bool `yaml:"ignore_same_owner_reusable_workflows"`
 }
 
 type UpdateToolConfigurationRuleOptions struct {
@@ -120,11 +130,20 @@ func (c *Config) suppressesFinding(f Finding) bool {
 	return false
 }
 
-func (c *Config) actionVersionPinningIgnoreSameOwner() bool {
+func (c *Config) actionVersionPinningIgnoreSameOwnerActions() bool {
 	if c == nil {
 		return false
 	}
-	return c.RuleOptions.ActionVersionPinning.IgnoreSameOwner
+	opts := c.RuleOptions.ActionVersionPinning
+	return opts.IgnoreSameOwner || opts.IgnoreSameOwnerActions
+}
+
+func (c *Config) actionVersionPinningIgnoreSameOwnerReusableWorkflows() bool {
+	if c == nil {
+		return false
+	}
+	opts := c.RuleOptions.ActionVersionPinning
+	return opts.IgnoreSameOwner || opts.IgnoreSameOwnerReusableWorkflows
 }
 
 func (c *Config) updateToolConfigurationRequireWorkflows() bool {

--- a/internal/scanner/config_test.go
+++ b/internal/scanner/config_test.go
@@ -38,11 +38,34 @@ overrides:
 	if cfg == nil {
 		t.Fatalf("cfg = nil")
 	}
-	if !cfg.actionVersionPinningIgnoreSameOwner() {
-		t.Fatal("expected ignore_same_owner to be enabled")
+	// The legacy ignore_same_owner switch must enable both per-kind options.
+	if !cfg.actionVersionPinningIgnoreSameOwnerActions() || !cfg.actionVersionPinningIgnoreSameOwnerReusableWorkflows() {
+		t.Fatal("expected legacy ignore_same_owner to enable both per-kind ignores")
 	}
 	if !cfg.updateToolConfigurationRequireWorkflows() {
 		t.Fatal("expected require_workflows to be enabled")
+	}
+}
+
+// The two per-kind ignore switches parse independently and do not imply each
+// other.
+func TestActionVersionPinningIgnoreOptions_PerKind(t *testing.T) {
+	var cfg Config
+	cfg.RuleOptions.ActionVersionPinning.IgnoreSameOwnerActions = true
+	if !cfg.actionVersionPinningIgnoreSameOwnerActions() {
+		t.Fatal("ignore_same_owner_actions must enable the actions ignore")
+	}
+	if cfg.actionVersionPinningIgnoreSameOwnerReusableWorkflows() {
+		t.Fatal("ignore_same_owner_actions must not imply the reusable-workflows ignore")
+	}
+
+	var cfg2 Config
+	cfg2.RuleOptions.ActionVersionPinning.IgnoreSameOwnerReusableWorkflows = true
+	if !cfg2.actionVersionPinningIgnoreSameOwnerReusableWorkflows() {
+		t.Fatal("ignore_same_owner_reusable_workflows must enable the reusable-workflows ignore")
+	}
+	if cfg2.actionVersionPinningIgnoreSameOwnerActions() {
+		t.Fatal("ignore_same_owner_reusable_workflows must not imply the actions ignore")
 	}
 }
 

--- a/internal/scanner/facts.go
+++ b/internal/scanner/facts.go
@@ -17,15 +17,16 @@ func (c *factCollector) addWarning(area, detail string) {
 }
 
 type ScanFacts struct {
-	Repository                              *github.Repository
-	RepositoryOwner                         string
-	DefaultBranch                           string
-	Workflows                               []WorkflowFact
-	ActionsSettings                         ActionsSettingsFacts
-	Dependabot                              DependabotFacts
-	Renovate                                RenovateFacts
-	ActionVersionPinningIgnoreSameOwner     bool
-	UpdateToolConfigurationRequireWorkflows bool
+	Repository                                           *github.Repository
+	RepositoryOwner                                      string
+	DefaultBranch                                        string
+	Workflows                                            []WorkflowFact
+	ActionsSettings                                      ActionsSettingsFacts
+	Dependabot                                           DependabotFacts
+	Renovate                                             RenovateFacts
+	ActionVersionPinningIgnoreSameOwnerActions           bool
+	ActionVersionPinningIgnoreSameOwnerReusableWorkflows bool
+	UpdateToolConfigurationRequireWorkflows              bool
 
 	// Incomplete lists facts that could not be determined because a GitHub
 	// request failed for a reason other than a clean 404 (timeout, rate limit,
@@ -146,11 +147,12 @@ type factCollector struct {
 
 func (c *factCollector) collectFacts(ctx context.Context, owner, repo string, repository *github.Repository, cfg *Config, dbg DebugLogger) *ScanFacts {
 	facts := &ScanFacts{
-		Repository:                              repository,
-		RepositoryOwner:                         owner,
-		DefaultBranch:                           "HEAD",
-		ActionVersionPinningIgnoreSameOwner:     cfg.actionVersionPinningIgnoreSameOwner(),
-		UpdateToolConfigurationRequireWorkflows: cfg.updateToolConfigurationRequireWorkflows(),
+		Repository:      repository,
+		RepositoryOwner: owner,
+		DefaultBranch:   "HEAD",
+		ActionVersionPinningIgnoreSameOwnerActions:           cfg.actionVersionPinningIgnoreSameOwnerActions(),
+		ActionVersionPinningIgnoreSameOwnerReusableWorkflows: cfg.actionVersionPinningIgnoreSameOwnerReusableWorkflows(),
+		UpdateToolConfigurationRequireWorkflows:              cfg.updateToolConfigurationRequireWorkflows(),
 	}
 
 	if repository != nil && repository.DefaultBranch != nil && *repository.DefaultBranch != "" {

--- a/internal/scanner/rules.go
+++ b/internal/scanner/rules.go
@@ -708,45 +708,77 @@ func evaluateActionVersionPinningRule(facts *ScanFacts) []Finding {
 			actions = findUnpinnedActionsInWorkflow(wf.Workflow, wf.Content)
 		}
 		for _, action := range actions {
-			if shouldIgnoreActionVersionPinning(action.name, facts) {
+			finding, ok := actionVersionPinningFinding(wf.Path, action, facts)
+			if !ok {
 				continue
 			}
-			msg := ruleMessage(ruleNameActionVersionPinning, "unpinned", map[string]string{
-				"Action": shortActionName(action.name),
-				"Ref":    action.version,
-			})
-			findings = append(findings, Finding{
-				// The ref is part of the ID because one file can reference the
-				// same action at two different mutable refs — actions/checkout@v4
-				// in one job and @v3 in another. Keying on path+name alone made
-				// those two findings share an ID, and dedupeFindings silently
-				// dropped the second: a real unpinned action disappearing from
-				// the report because a sibling finding got there first.
-				ID:          fmt.Sprintf("unpinned-%s-%s-%s", wf.Path, sanitizeID(action.name), sanitizeID(action.version)),
-				Severity:    SeverityHigh,
-				Title:       msg.Title,
-				Description: msg.Description,
-				File:        wf.Path,
-				Line:        action.line,
-				Remediation: msg.Fix,
-			})
+			findings = append(findings, finding)
 		}
 	}
 	return findings
 }
 
-func shouldIgnoreActionVersionPinning(actionName string, facts *ScanFacts) bool {
-	if facts == nil || !facts.ActionVersionPinningIgnoreSameOwner {
-		return false
+// actionVersionPinningFinding grades one unpinned reference, or reports ok=false
+// when configuration says to ignore it. Third-party refs stay high: a moved tag
+// runs someone else's code with the workflow's credentials. Refs owned by the
+// same user/org as the scanned repository are a smaller risk — the owner
+// controls both sides — but not zero, because a compromise of any one repo
+// under the owner pivots to every caller on the next mutable-ref move. So
+// same-owner refs grade low when pinned to a version tag (moves only when the
+// owner publishes) and medium when pinned to a branch (moves on every push),
+// with a per-kind config switch to ignore them entirely.
+func actionVersionPinningFinding(path string, action ActionRef, facts *ScanFacts) (Finding, bool) {
+	severity, msgKey := SeverityHigh, "unpinned"
+	if sameOwnerRef(action.name, facts.RepositoryOwner) {
+		if action.reusable && facts.ActionVersionPinningIgnoreSameOwnerReusableWorkflows {
+			return Finding{}, false
+		}
+		if !action.reusable && facts.ActionVersionPinningIgnoreSameOwnerActions {
+			return Finding{}, false
+		}
+		if isVersionTagRef(action.version) {
+			severity, msgKey = SeverityLow, "unpinned-same-owner-version"
+		} else {
+			severity, msgKey = SeverityMedium, "unpinned-same-owner-branch"
+		}
 	}
-	if strings.HasPrefix(actionName, "./") {
-		return true
+	msg := ruleMessage(ruleNameActionVersionPinning, msgKey, map[string]string{
+		"Action": shortActionName(action.name),
+		"Ref":    action.version,
+		"Kind":   actionRefKind(action.reusable),
+	})
+	return Finding{
+		// The ref is part of the ID because one file can reference the
+		// same action at two different mutable refs — actions/checkout@v4
+		// in one job and @v3 in another. Keying on path+name alone made
+		// those two findings share an ID, and dedupeFindings silently
+		// dropped the second: a real unpinned action disappearing from
+		// the report because a sibling finding got there first.
+		ID:          fmt.Sprintf("unpinned-%s-%s-%s", path, sanitizeID(action.name), sanitizeID(action.version)),
+		Severity:    severity,
+		Title:       msg.Title,
+		Description: msg.Description,
+		File:        path,
+		Line:        action.line,
+		Remediation: msg.Fix,
+	}, true
+}
+
+// sameOwnerRef reports whether the reference is owned by the same user or org
+// as the repository being scanned. Local (./) and docker:// refs never get
+// here — both extraction paths skip them.
+func sameOwnerRef(actionName, repoOwner string) bool {
+	owner, ok := actionRefOwner(actionName)
+	return ok && strings.EqualFold(owner, repoOwner)
+}
+
+// actionRefKind is the human word for what a reference points at, for finding
+// copy.
+func actionRefKind(reusable bool) string {
+	if reusable {
+		return "reusable workflow"
 	}
-	actionOwner, ok := actionRefOwner(actionName)
-	if !ok {
-		return false
-	}
-	return strings.EqualFold(actionOwner, facts.RepositoryOwner)
+	return "action"
 }
 
 func actionRefOwner(actionName string) (string, bool) {

--- a/internal/scanner/workflow.go
+++ b/internal/scanner/workflow.go
@@ -206,11 +206,13 @@ func hasDangerousTrigger(on interface{}) bool {
 	return false
 }
 
-// ActionRef holds information about an action reference
+// ActionRef holds information about an action reference. reusable marks a
+// reusable workflow call (jobs.<id>.uses) as opposed to a step action.
 type ActionRef struct {
-	name    string
-	version string
-	line    int
+	name     string
+	version  string
+	line     int
+	reusable bool
 }
 
 // checkoutSafeMajor is the first actions/checkout major release that refuses
@@ -273,6 +275,7 @@ func findUnpinnedActionsInWorkflow(workflow *WorkflowFile, content string) []Act
 		job := workflow.Jobs[name]
 		if action, ok := parseActionRef(job.Uses); ok && !isSHA(action.version) {
 			action.line = findUsesLine(content, job.Uses)
+			action.reusable = true
 			unpinned = append(unpinned, action)
 		}
 		for _, step := range job.Steps {
@@ -344,12 +347,24 @@ func findUnpinnedActions(content string) []ActionRef {
 					name:    actionName,
 					version: version,
 					line:    lineNum + 1,
+					// The regex fallback has no job/step structure to lean
+					// on, but a reusable workflow ref always embeds its
+					// workflow path.
+					reusable: strings.Contains(actionName, "/.github/workflows/"),
 				})
 			}
 		}
 	}
 
 	return unpinned
+}
+
+// isVersionTagRef reports whether a mutable ref looks like a version tag (v4,
+// 4, v4.1.1, v2-beta) rather than a branch. Used to grade same-owner refs: a
+// version tag moves only when the owner publishes a release, while a branch
+// moves on every push.
+func isVersionTagRef(ref string) bool {
+	return versionTagMajorRegex.MatchString(ref)
 }
 
 // isSHA checks if a string is a full SHA-1 or SHA-256 object ID.

--- a/internal/scanner/workflow_test.go
+++ b/internal/scanner/workflow_test.go
@@ -94,8 +94,9 @@ func TestEvaluateActionVersionPinningRuleFallsBackToRegexForInvalidYAML(t *testi
 
 func TestEvaluateActionVersionPinningRule_IgnoreSameOwner(t *testing.T) {
 	facts := &ScanFacts{
-		RepositoryOwner:                     "BretFisher",
-		ActionVersionPinningIgnoreSameOwner: true,
+		RepositoryOwner: "BretFisher",
+		ActionVersionPinningIgnoreSameOwnerActions:           true,
+		ActionVersionPinningIgnoreSameOwnerReusableWorkflows: true,
 		Workflows: []WorkflowFact{{
 			Path:    ".github/workflows/ci.yml",
 			Content: "steps:\n  - uses: BretFisher/internal-action@v1\n  - uses: actions/checkout@v4\n",
@@ -111,21 +112,77 @@ func TestEvaluateActionVersionPinningRule_IgnoreSameOwner(t *testing.T) {
 	}
 }
 
-func TestEvaluateActionVersionPinningRule_SameOwnerStillFlaggedByDefault(t *testing.T) {
-	facts := &ScanFacts{
-		RepositoryOwner: "bretfisher",
-		Workflows: []WorkflowFact{{
-			Path:    ".github/workflows/ci.yml",
-			Content: "steps:\n  - uses: bretfisher/internal-action@v1\n",
-		}},
+// The two ignore switches are per kind: silencing same-owner actions must not
+// silence same-owner reusable workflow calls, and vice versa.
+func TestEvaluateActionVersionPinningRule_IgnoreSameOwnerIsPerKind(t *testing.T) {
+	content := "on: push\njobs:\n  call:\n    uses: bretfisher/shared/.github/workflows/build.yml@main\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: bretfisher/internal-action@v1\n"
+	workflow := &WorkflowFile{}
+	if err := yaml.Unmarshal([]byte(content), workflow); err != nil {
+		t.Fatalf("yaml.Unmarshal() error: %v", err)
 	}
+	workflows := []WorkflowFact{{Path: ".github/workflows/ci.yml", Content: content, Workflow: workflow, Valid: true}}
 
-	findings := evaluateActionVersionPinningRule(facts)
-	if len(findings) != 1 {
-		t.Fatalf("findings len = %d, want 1\nfindings=%+v", len(findings), findings)
+	t.Run("ignore actions keeps the reusable workflow finding", func(t *testing.T) {
+		facts := &ScanFacts{
+			RepositoryOwner: "bretfisher",
+			ActionVersionPinningIgnoreSameOwnerActions: true,
+			Workflows: workflows,
+		}
+		findings := evaluateActionVersionPinningRule(facts)
+		if len(findings) != 1 || !strings.Contains(findings[0].Title, "bretfisher/shared") {
+			t.Fatalf("findings = %+v, want only the reusable workflow", findings)
+		}
+		if !strings.Contains(findings[0].Title, "reusable workflow") {
+			t.Fatalf("title = %q, want it to name the reusable workflow kind", findings[0].Title)
+		}
+	})
+
+	t.Run("ignore reusable workflows keeps the action finding", func(t *testing.T) {
+		facts := &ScanFacts{
+			RepositoryOwner: "bretfisher",
+			ActionVersionPinningIgnoreSameOwnerReusableWorkflows: true,
+			Workflows: workflows,
+		}
+		findings := evaluateActionVersionPinningRule(facts)
+		if len(findings) != 1 || !strings.Contains(findings[0].Title, "bretfisher/internal-action") {
+			t.Fatalf("findings = %+v, want only the action", findings)
+		}
+	})
+}
+
+// Same-owner refs still flag by default, but graded by how the ref can move:
+// low for a version tag (moves only on publish), medium for a branch (moves on
+// every push). Third-party refs stay high regardless of ref shape.
+func TestEvaluateActionVersionPinningRule_SameOwnerSeverityTiers(t *testing.T) {
+	cases := []struct {
+		name         string
+		uses         string
+		wantSeverity string
+	}{
+		{"same-owner action on version tag", "bretfisher/internal-action@v1", SeverityLow},
+		{"same-owner action on dotted version tag", "bretfisher/internal-action@v1.2.3", SeverityLow},
+		{"same-owner action on branch", "bretfisher/internal-action@main", SeverityMedium},
+		{"same-owner reusable-workflow-style ref on branch", "bretfisher/shared/.github/workflows/build.yml@main", SeverityMedium},
+		{"third-party action on version tag", "actions/checkout@v4", SeverityHigh},
+		{"third-party action on branch", "docker/login-action@master", SeverityHigh},
 	}
-	if !strings.Contains(findings[0].Title, "bretfisher/internal-action") {
-		t.Fatalf("unexpected finding: %+v", findings[0])
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			facts := &ScanFacts{
+				RepositoryOwner: "bretfisher",
+				Workflows: []WorkflowFact{{
+					Path:    ".github/workflows/ci.yml",
+					Content: "steps:\n  - uses: " + tc.uses + "\n",
+				}},
+			}
+			findings := evaluateActionVersionPinningRule(facts)
+			if len(findings) != 1 {
+				t.Fatalf("findings = %+v, want one", findings)
+			}
+			if findings[0].Severity != tc.wantSeverity {
+				t.Fatalf("severity = %q, want %q", findings[0].Severity, tc.wantSeverity)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

Splits the pinning rule's `ignore_same_owner` option into two per-kind options and stops grading same-owner refs identically to third-party ones.

**Config** (`rule_options: workflows/action-version-pinning:`):
- `ignore_same_owner_actions` — ignore same-owner *action* refs
- `ignore_same_owner_reusable_workflows` — ignore same-owner *reusable workflow call* refs
- `ignore_same_owner` — legacy key, kept as shorthand for both (existing configs keep working)

**Default grading** (no ignores set):

| Reference | Ref shape | Severity |
|---|---|---|
| any other owner | any mutable ref | **high** (unchanged) |
| same user/org | version tag (`v4`, `v4.1.1`) | **low** |
| same user/org | branch / anything else (`main`) | **medium** |

Rationale: same owner is not same repo — a compromise of one repo under the owner pivots into every caller on the next mutable-ref move. A version tag moves only on publish; a branch moves on every push, hence the tier split.

## Docs

The rule page now covers the cross-repo pivot risk, the mitigation pairing (version tag + immutable releases on the referenced repo), and GitHub's `sha_pinning_required` enforcement exemption — "Reusable workflows can still be referenced by tag", **tags only**: a same-owner reusable workflow pinned to `@main` stops running the moment that setting is enabled. (Per GitHub's docs the exemption is not scoped to same user/org.)

## Testing

- Unit: severity-tier table (6 cases), per-kind ignore independence (2 subtests), legacy-alias config parsing, per-kind accessor independence.
- Live sanity: `gasa run bretfisher/docker-vackup --no-config` now reports `bretfisher/super-linter-workflow` as **medium** ("Same-owner reusable workflow pinned to a branch") instead of high.
- e2e goldens unchanged — no fixture uses same-owner refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph8rsxumDhcBNKHC5EwZMN
