### PR TITLE
Move inline zizmor ignores to .github/zizmor.yml

### DIFF
--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -1,0 +1,1 @@
+../zizmor.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,8 +33,8 @@ jobs:
     ### you can also call workflows from inside the same repository via file path
 
     # FIXME: customize uri to point to your own reusable linter repository
-    # NOTE: zizmor scanner rule ignore added because we control sha pins via reusable workflow, not calling workflow
-    uses: bretfisher/super-linter-workflow/.github/workflows/reusable-super-linter.yaml@main # zizmor: ignore[unpinned-uses]
+    # NOTE: unpinned-uses ignore lives in .github/zizmor.yml (we control sha pins via reusable workflow, not calling workflow)
+    uses: bretfisher/super-linter-workflow/.github/workflows/reusable-super-linter.yaml@main
     # Prefer .github/super-linter.env for enabling/disabling individual linters rather than extra-envs here.
 
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ jobs:
     steps:
       - name: Checkout
         # persist-credentials required: this job pushes the release tag via `git push origin`
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked]
+        # artipacked ignore lives in .github/zizmor.yml (inline ignores break Dependabot comment updates)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,19 @@
+# zizmor configuration: https://docs.zizmor.sh/configuration/
+#
+# Keep zizmor ignores here instead of inline `# zizmor: ignore[...]` comments
+# on SHA-pinned `uses:` lines. An extra comment on those lines prevents
+# Dependabot from updating the `# vX.Y.Z` version comment (it only rewrites
+# comments that end with the version), and zizmor >= 1.29 fails to parse the
+# version comment at all when a second comment shares the line, tripping
+# ref-version-mismatch on every bump.
+rules:
+  artipacked:
+    # release.yml checkout must persist credentials: the release job pushes
+    # the release tag via `git push origin`.
+    ignore:
+      - release.yml
+  unpinned-uses:
+    # lint.yml calls our reusable super-linter workflow by @main on purpose:
+    # sha pins are controlled inside the reusable workflow, not the caller.
+    ignore:
+      - lint.yml


### PR DESCRIPTION
Inline `zizmor: ignore[...]` comments on SHA-pinned `uses:` lines break two tools at once:

1. **Dependabot** only rewrites the `# vX.Y.Z` version comment when the comment *ends with* the version ([file_updater.rb](https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/file_updater.rb)), so a trailing ignore comment leaves the version comment stale on every SHA bump — this is what broke CI on #47.
2. **zizmor >= 1.29** cannot parse the version comment when any second comment shares the line (either order), tripping `ref-version-mismatch` even when the version is correct.

Fix: move both inline ignores (artipacked in release.yml, unpinned-uses in lint.yml) into a new `.github/zizmor.yml`, keeping pinned lines as clean `SHA # vX.Y.Z` that Dependabot knows how to rewrite.

Verified with actionlint, zizmor (default + pedantic/online personas), and poutine — findings identical to baseline, both ignores honored via config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111XFSxzYAiNJTG5BCnPeaZ